### PR TITLE
Harness tool hardening: ledger wiring, CRLF preservation, fail-open gate, grep literal

### DIFF
--- a/.changeset/harness-tool-hardening.md
+++ b/.changeset/harness-tool-hardening.md
@@ -1,0 +1,28 @@
+---
+"@agent-sh/harness-read": minor
+"@agent-sh/harness-write": minor
+"@agent-sh/harness-grep": minor
+"@agent-sh/harness-bash": minor
+"@agent-sh/harness-tools": minor
+---
+
+Harness tool hardening — fixes for failure modes surfaced by real-model use.
+
+- **tools**: wire a shared per-process `InMemoryLedger` into the read and
+  write/edit sessions. Previously neither session carried a ledger, so Read
+  recorded nothing and every Edit/Write hit `NOT_READ_THIS_SESSION` and
+  hard-denied — pushing models to fall back to `cat`/`sed` via Bash. The
+  read-before-edit gate now works as designed.
+- **write**: preserve the file's original line endings (and BOM) on edit. Edits
+  matched on CRLF→LF-normalized content but wrote the normalized (LF) bytes back,
+  silently converting CRLF files to LF. Matching stays normalized; output keeps
+  the file's convention.
+- **write**: the read-gate now fails open per Read spec D11 — a missing ledger
+  entry asks the permission hook (deny only on explicit deny) or proceeds with a
+  warning when no hook is wired, instead of a hard deny. `STALE_READ` stays hard.
+- **read**: read the file once for both content and sha256 (was reading twice);
+  remove env-gated debug `console.error` from shipped source.
+- **grep**: add `fixed_strings` for literal search (ripgrep `-F`), skipping the
+  regex compile-probe; `INVALID_REGEX` now points to it as the escape-free path.
+- **bash**: tool description steers stalling network calls (curl/wget) to
+  `background: true` or an explicit client timeout, alongside servers/watchers.

--- a/agent-knowledge/design/grep.md
+++ b/agent-knowledge/design/grep.md
@@ -55,7 +55,6 @@ Non-goals: filename/path search (that is the Glob tool), semantic/AST search, ve
 ### Deliberate omissions
 
 - No `replace_all` / `-r`. This tool is read-only; mutations go through Edit.
-- No `--fixed-strings` flag. If the model wants literal search, it escapes regex metachars. We flag this in the description with an example (`interface\{\}`).
 - No `hidden` or `no_ignore`. The default posture is "respect gitignore, skip hidden." A workspace-level override is a session-config decision, not a per-call parameter — see §6.
 - No `sort_by`. Results in `content` mode are mtime-sorted (newest first, matching Glob and opencode). Results in `files_with_matches` mode are mtime-sorted. `count` is alphabetical by path for stable diffs.
 - No `binary`. Binary files are skipped (rg default); there is no escape hatch at the tool boundary.
@@ -64,7 +63,8 @@ Non-goals: filename/path search (that is the Glob tool), semantic/AST search, ve
 ### Parameter validation
 
 - `pattern` empty → `INVALID_PARAM`: "pattern is required".
-- `pattern` does not compile → `INVALID_REGEX`: surface ripgrep's error verbatim (it already names the offending character).
+- `pattern` does not compile → `INVALID_REGEX`: surface ripgrep's error verbatim (it already names the offending character). The error hint also points to `fixed_strings: true` as the escape-free alternative.
+- `fixed_strings: true` → pattern is passed to ripgrep with `-F` (literal search); the regex compile-probe is skipped (a literal cannot be an invalid regex). Use to search exact strings with metacharacters (`( ) . * { }`) without escaping.
 - `output_mode` unknown → `INVALID_PARAM`: list the three valid values.
 - `context_*` set while `output_mode != "content"` → `INVALID_PARAM`. Context only makes sense for line output; rejecting the combination keeps the surface honest.
 - `head_limit < 0` or `offset < 0` → `INVALID_PARAM`.
@@ -74,7 +74,7 @@ Non-goals: filename/path search (that is the Glob tool), semantic/AST search, ve
 
 Tool description must call out:
 
-> Regex syntax is ripgrep's (Rust `regex` crate). To match literal `{` `}` `(` `)` `[` `]` `.` `*` `+` `?` `|` `^` `$` `\\`, escape them (`interface\\{\\}` to find `interface{}`). By default `.` does not match newlines — set `multiline: true` if your pattern needs to cross lines.
+> Regex syntax is ripgrep's (Rust `regex` crate). To match literal `{` `}` `(` `)` `[` `]` `.` `*` `+` `?` `|` `^` `$` `\\`, escape them (`interface\\{\\}` to find `interface{}`) — or set `fixed_strings: true` to treat the whole pattern as a literal string with no escaping. By default `.` does not match newlines — set `multiline: true` if your pattern needs to cross lines.
 
 Research backing: the Claude Code Grep tool's description carries the same warning because models consistently try `interface{}` on Go code and get zero hits otherwise (see `agent-knowledge/agent-search-tools.md` §"Ripgrep as the Universal Engine").
 

--- a/packages/bash/src/schema.ts
+++ b/packages/bash/src/schema.ts
@@ -159,7 +159,7 @@ export const BASH_TOOL_DESCRIPTION = `Run a single shell command in a bash subpr
 Usage:
 - 'cd' carries over to subsequent calls if it stays inside the workspace; otherwise the cwd is reset. Environment variables do NOT persist across calls — set them inline (FOO=bar some-cmd) or via 'env'.
 - For non-shell code, use language one-liners: 'python -c "print(2+2)"', 'node -e "console.log(2+2)"', 'deno eval "console.log(2+2)"'. For multi-line scripts, write a temp file with the write tool and invoke the interpreter on it.
-- Long-running processes (servers, watchers) MUST use background: true. The tool returns a job_id; poll output with bash_output(job_id). Do not leave a foreground command running past the 5-minute wall-clock backstop.
+- Long-running processes (servers, watchers) and network requests (curl/wget) that may stall MUST use background: true, OR pass an explicit client-side timeout (e.g. curl --max-time N). The tool returns a job_id; poll output with bash_output(job_id). Do not leave a foreground command running past the 5-minute wall-clock backstop.
 - No interactive commands. Anything that needs stdin (pagers, Y/n prompts, REPLs, 'git commit' without -m) will hang until the inactivity timeout. Use flags to make commands non-interactive (--yes, -y, --no-pager) or pipe 'echo "y" |' in front.
 - Inactivity timeout resets on any output; default 60000 ms. Override with timeout_ms. Wall-clock backstop is 5 minutes for foreground calls.
 - Prefer this tool over other ways of running shell commands. For filename search prefer 'glob'; for content search prefer 'grep'.`;

--- a/packages/grep/src/engine.ts
+++ b/packages/grep/src/engine.ts
@@ -123,6 +123,7 @@ function buildArgs(input: GrepEngineInput, jsonMode: boolean): string[] {
   }
   if (input.caseInsensitive) args.push("-i");
   if (input.multiline) args.push("-U", "--multiline-dotall");
+  if (input.fixedStrings) args.push("-F");
   if (input.type) args.push(`--type=${input.type}`);
   if (input.glob) args.push(`--glob=${input.glob}`);
   if (!input.countOnly) {

--- a/packages/grep/src/grep.ts
+++ b/packages/grep/src/grep.ts
@@ -42,6 +42,7 @@ interface NormalizedParams {
   readonly outputMode: "files_with_matches" | "content" | "count";
   readonly caseInsensitive: boolean;
   readonly multiline: boolean;
+  readonly fixedStrings: boolean;
   readonly contextBefore: number;
   readonly contextAfter: number;
   readonly headLimit: number;
@@ -68,6 +69,7 @@ function normalizeParams(p: GrepParams): NormalizedParams | ToolError {
     outputMode,
     caseInsensitive: p.case_insensitive ?? false,
     multiline: p.multiline ?? false,
+    fixedStrings: p.fixed_strings ?? false,
     contextBefore,
     contextAfter,
     headLimit: p.head_limit ?? DEFAULT_HEAD_LIMIT,
@@ -91,6 +93,7 @@ function engineInput(
     ...(n.type !== undefined ? { type: n.type } : {}),
     ...(n.caseInsensitive ? { caseInsensitive: true } : {}),
     ...(n.multiline ? { multiline: true } : {}),
+    ...(n.fixedStrings ? { fixedStrings: true } : {}),
     ...(n.contextBefore > 0 ? { contextBefore: n.contextBefore } : {}),
     ...(n.contextAfter > 0 ? { contextAfter: n.contextAfter } : {}),
   };
@@ -160,15 +163,20 @@ export async function grep(
     );
   }
 
-  const compile = await compileProbe(normed.pattern);
-  if (!compile.ok) {
-    return err(
-      toolError(
-        "INVALID_REGEX",
-        `${compile.message}\n\nHint: escape literal regex metacharacters (e.g. 'interface\\{\\}' for 'interface{}'), or use a character class. '.' does not match newlines unless multiline: true.`,
-        { meta: { pattern: normed.pattern } },
-      ),
-    );
+  // A literal string (fixed_strings) cannot be invalid regex, so skip the
+  // probe; otherwise a pattern like 'interface{}' would be wrongly rejected
+  // as INVALID_REGEX even though -F searches it verbatim.
+  if (!normed.fixedStrings) {
+    const compile = await compileProbe(normed.pattern);
+    if (!compile.ok) {
+      return err(
+        toolError(
+          "INVALID_REGEX",
+          `${compile.message}\n\nHint: escape literal regex metacharacters (e.g. 'interface\\{\\}' for 'interface{}'), or use a character class. '.' does not match newlines unless multiline: true.`,
+          { meta: { pattern: normed.pattern } },
+        ),
+      );
+    }
   }
 
   const { signal, cancel, timedOut } = withTimeout(session);

--- a/packages/grep/src/schema.ts
+++ b/packages/grep/src/schema.ts
@@ -23,6 +23,7 @@ export const GrepParamsSchema = v.strictObject({
   output_mode: v.optional(OutputModeSchema),
   case_insensitive: v.optional(v.boolean()),
   multiline: v.optional(v.boolean()),
+  fixed_strings: v.optional(v.boolean()),
   context_before: v.optional(
     v.pipe(v.number(), v.integer(), v.minValue(0, "context_before must be >= 0")),
   ),
@@ -125,7 +126,7 @@ export const GREP_TOOL_NAME = "grep";
 export const GREP_TOOL_DESCRIPTION = `Search file contents with a ripgrep-compatible regex and return structured results.
 
 Usage:
-- pattern is required. Regex syntax is ripgrep's (Rust regex). Escape literal metacharacters: use 'interface\\\\{\\\\}' to match 'interface{}'. '.' does not match newlines unless multiline: true.
+- pattern is required. Regex syntax is ripgrep's (Rust regex). Escape literal metacharacters: use 'interface\\\\{\\\\}' to match 'interface{}'. '.' does not match newlines unless multiline: true. To search an EXACT string with regex metacharacters like ( ) . * { } treated as plain text, set fixed_strings: true instead of escaping (e.g. fixed_strings: true with pattern foo(bar) or a.b.c).
 - path defaults to the session cwd. Absolute paths preferred; relative paths resolve against cwd.
 - Filter by the 'glob' parameter (e.g. '*.ts', '*.{js,tsx}') or by 'type' (e.g. 'js', 'py', 'rust'). 'type' takes ONE name only — for multiple extensions, use 'glob' with a brace list like '*.{ts,tsx,js}'. 'type' is more efficient for standard languages.
 - Default output_mode is 'files_with_matches' — cheap path-only results. Use this first to decide whether to pay for content.
@@ -174,6 +175,11 @@ export const grepToolDefinition: ToolDefinition = {
         type: "boolean",
         description:
           "Allow . to match newlines and patterns to cross lines. Default false.",
+      },
+      fixed_strings: {
+        type: "boolean",
+        description:
+          "Treat pattern as an exact literal string, not a regex (ripgrep -F). Use to search strings with metacharacters like ( ) . * { } as plain text without escaping. Default false.",
       },
       context_before: {
         type: "integer",

--- a/packages/grep/src/types.ts
+++ b/packages/grep/src/types.ts
@@ -14,6 +14,7 @@ export interface GrepParams {
   readonly output_mode?: GrepOutputMode | undefined;
   readonly case_insensitive?: boolean | undefined;
   readonly multiline?: boolean | undefined;
+  readonly fixed_strings?: boolean | undefined;
   readonly context_before?: number | undefined;
   readonly context_after?: number | undefined;
   readonly context?: number | undefined;
@@ -32,6 +33,7 @@ export interface GrepEngineInput {
   readonly type?: string;
   readonly caseInsensitive?: boolean;
   readonly multiline?: boolean;
+  readonly fixedStrings?: boolean;
   readonly contextBefore?: number;
   readonly contextAfter?: number;
   readonly maxColumns: number;

--- a/packages/grep/test/grep.test.ts
+++ b/packages/grep/test/grep.test.ts
@@ -204,6 +204,30 @@ describe("grep — regex + error surfaces", () => {
     expect(r.error.message).toMatch(/escape literal regex|regex parse/i);
   });
 
+  it("fixed_strings: true searches a metacharacter pattern verbatim instead of raising INVALID_REGEX", async () => {
+    const dir = makeTempDir();
+    write(dir, "a.go", "type Foo interface{}\n");
+    const r = await grep(
+      { pattern: "interface{}", fixed_strings: true },
+      makeSession(dir),
+    );
+    assertKind(r, "files_with_matches");
+    expect(r.paths.some((p) => p.endsWith("/a.go"))).toBe(true);
+  });
+
+  it("fixed_strings: true treats '.' as a literal, not a wildcard", async () => {
+    const dir = makeTempDir();
+    write(dir, "a.ts", "aXb\na.b\n");
+    const r = await grep(
+      { pattern: "a.b", fixed_strings: true, output_mode: "content" },
+      makeSession(dir),
+    );
+    assertKind(r, "content");
+    expect(r.output).toContain("a.b");
+    expect(r.output).not.toContain("aXb");
+    expect(r.meta.totalMatches).toBe(1);
+  });
+
   it("returns NOT_FOUND for a missing path", async () => {
     const dir = makeTempDir();
     const r = await grep(

--- a/packages/harness-e2e/src/agent.ts
+++ b/packages/harness-e2e/src/agent.ts
@@ -1,5 +1,14 @@
 import type { OllamaMessage, OllamaTool, OllamaToolCall } from "./ollama.js";
 import { ollamaChat } from "./ollama.js";
+import { openaiChat } from "./openai.js";
+
+// Chat client selector. The agent loop is transport-agnostic; E2E_BACKEND=openai
+// routes to an OpenAI /v1 server (e.g. local llama.cpp on :8001) instead of
+// Ollama /api/chat. Both return the same OllamaChatResponse shape.
+const chatClient =
+  (process.env.E2E_BACKEND ?? "").toLowerCase() === "openai"
+    ? openaiChat
+    : ollamaChat;
 
 export interface ToolExecutor {
   readonly tool: OllamaTool;
@@ -55,7 +64,7 @@ export async function runAgent(opts: AgentRunOptions): Promise<AgentRunResult> {
     if (opts.baseUrl !== undefined) {
       (chatOpts as { baseUrl: string }).baseUrl = opts.baseUrl;
     }
-    const res = await ollamaChat(chatOpts);
+    const res = await chatClient(chatOpts);
     const msg = res.message;
     const calls = msg.tool_calls ?? [];
 

--- a/packages/harness-e2e/src/ollama.ts
+++ b/packages/harness-e2e/src/ollama.ts
@@ -79,6 +79,13 @@ export async function ollamaModelAvailable(
   model: string,
   baseUrl = "http://localhost:11434",
 ): Promise<boolean> {
+  // When the harness is pointed at an OpenAI /v1 server (E2E_BACKEND=openai,
+  // e.g. local llama.cpp on :8001), probe that surface instead of /api/show.
+  if ((process.env.E2E_BACKEND ?? "").toLowerCase() === "openai") {
+    const { openaiModelAvailable } = await import("./openai.js");
+    const oaiBase = process.env.E2E_OPENAI_BASE_URL ?? "http://127.0.0.1:8001/v1";
+    return openaiModelAvailable(model, oaiBase);
+  }
   try {
     const res = await fetch(`${baseUrl}/api/show`, {
       method: "POST",

--- a/packages/harness-e2e/src/openai.ts
+++ b/packages/harness-e2e/src/openai.ts
@@ -1,0 +1,163 @@
+// OpenAI-compatible chat backend for the e2e harness.
+//
+// Why this exists: the e2e runner originally spoke only Ollama-native /api/chat.
+// A local llama.cpp server (e.g. the Qwen3.6-27B daily driver on :8001) exposes
+// the OpenAI /v1/chat/completions surface instead. This adapter lets the same
+// e2e suites drive that server with no other changes — it translates the OpenAI
+// request/response shape to/from the OllamaChatResponse the runner consumes.
+//
+// Mapping notes:
+//   - tool_calls.function.arguments is a JSON STRING in OpenAI, an OBJECT in the
+//     Ollama shape the runner expects -> parse it here.
+//   - tool result messages: OpenAI wants { role:"tool", tool_call_id, content };
+//     the runner produces { role:"tool", content, tool_name } -> we synthesize a
+//     tool_call_id from the assistant's prior tool_calls by name.
+//   - thinking models (Qwen) emit reasoning the OpenAI surface returns in content;
+//     no separate "think" flag — sampling temperature is the only knob we pass.
+import type {
+  OllamaChatOptions,
+  OllamaChatResponse,
+  OllamaMessage,
+  OllamaToolCall,
+} from "./ollama.js";
+
+interface OpenAIToolCall {
+  readonly id: string;
+  readonly type: "function";
+  readonly function: { readonly name: string; readonly arguments: string };
+}
+
+interface OpenAIChoiceMessage {
+  readonly role: string;
+  readonly content: string | null;
+  readonly tool_calls?: OpenAIToolCall[];
+}
+
+interface OpenAIChatResponse {
+  readonly model?: string;
+  readonly choices: ReadonlyArray<{
+    readonly message: OpenAIChoiceMessage;
+    readonly finish_reason?: string;
+  }>;
+}
+
+/** Translate the runner's Ollama-shaped messages into OpenAI chat messages. */
+function toOpenAIMessages(
+  messages: readonly OllamaMessage[],
+): Array<Record<string, unknown>> {
+  // track the most recent assistant tool_calls so tool results can be paired by name
+  let lastCallIdByName = new Map<string, string>();
+  const out: Array<Record<string, unknown>> = [];
+  for (const m of messages) {
+    if (m.role === "assistant" && m.tool_calls && m.tool_calls.length > 0) {
+      lastCallIdByName = new Map();
+      const calls = m.tool_calls.map((c, i) => {
+        const id = `call_${out.length}_${i}`;
+        lastCallIdByName.set(c.function.name, id);
+        return {
+          id,
+          type: "function" as const,
+          function: {
+            name: c.function.name,
+            arguments: JSON.stringify(c.function.arguments ?? {}),
+          },
+        };
+      });
+      out.push({ role: "assistant", content: m.content ?? "", tool_calls: calls });
+      continue;
+    }
+    if (m.role === "tool") {
+      const id =
+        (m.tool_name && lastCallIdByName.get(m.tool_name)) ?? "call_unknown";
+      out.push({ role: "tool", tool_call_id: id, content: m.content });
+      continue;
+    }
+    out.push({ role: m.role, content: m.content });
+  }
+  return out;
+}
+
+/** OpenAI /v1/chat/completions call returning the OllamaChatResponse shape. */
+export async function openaiChat(
+  opts: OllamaChatOptions,
+): Promise<OllamaChatResponse> {
+  // Prefer the explicit OpenAI base env; ignore an Ollama-style baseUrl the
+  // test may have passed (those default to :11434/api, wrong surface here).
+  const baseUrl =
+    process.env.E2E_OPENAI_BASE_URL ??
+    (opts.baseUrl && opts.baseUrl.includes("/v1")
+      ? opts.baseUrl
+      : "http://127.0.0.1:8001/v1");
+  const apiKey = process.env.E2E_OPENAI_API_KEY ?? "aviary-local";
+  const body = {
+    model: opts.model,
+    messages: toOpenAIMessages(opts.messages),
+    tools: opts.tools,
+    stream: false,
+    temperature: opts.temperature ?? 0.6,
+  };
+  const fetchFn = opts.fetchImpl ?? fetch;
+  const res = await fetchFn(`${baseUrl}/chat/completions`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`OpenAI chat failed: ${res.status} ${await res.text()}`);
+  }
+  const data = (await res.json()) as OpenAIChatResponse;
+  const choice = data.choices[0];
+  if (!choice) {
+    throw new Error("OpenAI chat returned no choices");
+  }
+  const toolCalls: OllamaToolCall[] | undefined = choice.message.tool_calls?.map(
+    (c) => ({
+      type: "function" as const,
+      function: {
+        name: c.function.name,
+        arguments: parseArgs(c.function.arguments),
+      },
+    }),
+  );
+  return {
+    model: data.model ?? opts.model,
+    created_at: "",
+    message: {
+      role: "assistant",
+      content: choice.message.content ?? "",
+      ...(toolCalls ? { tool_calls: toolCalls } : {}),
+    },
+    done: true,
+    ...(choice.finish_reason ? { done_reason: choice.finish_reason } : {}),
+  };
+}
+
+function parseArgs(raw: string): Record<string, unknown> {
+  try {
+    const v = JSON.parse(raw || "{}");
+    return v && typeof v === "object" ? (v as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
+/** Liveness probe: GET {baseUrl}/models on the OpenAI surface. */
+export async function openaiModelAvailable(
+  model: string,
+  baseUrl = "http://127.0.0.1:8001/v1",
+): Promise<boolean> {
+  try {
+    const apiKey = process.env.E2E_OPENAI_API_KEY ?? "aviary-local";
+    const res = await fetch(`${baseUrl}/models`, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    if (!res.ok) return false;
+    // llama.cpp serves a single model; presence of the endpoint is enough.
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/harness-e2e/test/crlf.e2e.test.ts
+++ b/packages/harness-e2e/test/crlf.e2e.test.ts
@@ -68,15 +68,15 @@ describe(`CRLF e2e [${LABEL}]`, () => {
   });
 
   // CRLF fixture. Real-world scenario: a file authored on Windows lands in
-  // the tree and the model has to edit a line. The engine normalizes CRLF
-  // to LF on both sides (per spec §5.1). We assert:
+  // the tree and the model has to edit a line. The engine matches on
+  // LF-normalized text (per spec §5.1) but re-applies the file's original
+  // CRLF style on write, so a Windows file stays Windows. We assert:
   //   1. The model successfully edits despite CRLF line endings.
   //   2. The edit applied correctly at the targeted line.
-  //   3. Post-edit the file has no stray CR bytes (\r), because the spec
-  //      normalizes to LF. If the engine ever regresses and leaves mixed
-  //      endings, this test catches it.
+  //   3. Post-edit the file still uses CRLF (CR bytes preserved). If the
+  //      engine ever regresses and flattens to LF, this test catches it.
   it.runIf(() => available)(
-    "edits a CRLF file; output is LF-terminated and content is correct",
+    "edits a CRLF file; content is correct and CRLF endings are preserved",
     async () => {
       const root = mkRoot();
       const target = path.join(root, "win.txt");
@@ -131,10 +131,16 @@ describe(`CRLF e2e [${LABEL}]`, () => {
       // Correctness: the edit landed.
       expect(post).toContain("BRAVO");
       expect(post).not.toContain("bravo");
-      // Engine contract §5.1: no stray CR bytes after edit.
-      expect(postBytes.includes(0x0d)).toBe(false);
-      // Other lines are intact.
-      expect(post.split("\n")).toEqual(["alpha", "BRAVO", "charlie", "delta", ""]);
+      // Engine contract §5.1: CRLF style preserved — CR bytes survive.
+      expect(postBytes.includes(0x0d)).toBe(true);
+      // Other lines are intact, and the file splits cleanly on CRLF.
+      expect(post.split("\r\n")).toEqual([
+        "alpha",
+        "BRAVO",
+        "charlie",
+        "delta",
+        "",
+      ]);
     },
     300_000,
   );

--- a/packages/harness-e2e/test/grep.e2e.hard.test.ts
+++ b/packages/harness-e2e/test/grep.e2e.hard.test.ts
@@ -371,6 +371,70 @@ describe(`grep e2e hard [${LABEL}]`, () => {
     600_000,
   );
 
+  // G3b: fixed_strings — exact literal with parens. Model should set
+  // fixed_strings: true OR escape the parens (accept either, like G3 accepts
+  // escape-or-recover). Stochastic across small models, so wrapped in pass@k.
+  it.runIf(() => available)(
+    "G3b fixed-strings: finds literal 'format(msg)' via fixed_strings or escaped parens",
+    async () => {
+      const r = await passAtK({
+        n: 3,
+        k: 2,
+        label: "G3b",
+        run: async () => {
+          const root = mkRoot();
+          writeFile(
+            root,
+            "src/log.ts",
+            "export function info(msg) {\n  logger.info(format(msg));\n}\n",
+          );
+          writeFile(
+            root,
+            "src/other.ts",
+            "export function warn(msg) {\n  logger.info(msg);\n}\n",
+          );
+
+          const tools = [pickGrepExecutor(makeSession(root))];
+          const { trace, onTrace } = collectTrace();
+
+          const res = await runE2E(
+            runOpts(
+              SYSTEM_PROMPT,
+              `In ${root}, find the file containing the exact literal text 'format(msg)', including the parentheses. Tell me which file(s) contain it.`,
+              tools,
+              8,
+              onTrace,
+            ),
+          );
+
+          // Accept either approach: fixed_strings: true, or an escaped-parens
+          // regex pattern (\\( … \\)). Mirrors G3's escape-or-recover policy.
+          const usedFixedOrEscaped = someCall(trace, (a) => {
+            if (a.fixed_strings === true) return true;
+            const p = typeof a.pattern === "string" ? a.pattern : "";
+            return /\\\(/.test(p) || /\\\)/.test(p);
+          });
+          const mentionsLog = /log\.ts/.test(res.finalContent);
+          const skipsOther = !/other\.ts/.test(res.finalContent);
+          return {
+            ok: usedFixedOrEscaped && mentionsLog && skipsOther,
+            detail: {
+              turns: trace.turns,
+              seq: trace.toolSeq,
+              grepArgs: grepCallsIn(trace).map((a) => ({
+                pattern: a.pattern,
+                fixed_strings: a.fixed_strings,
+              })),
+              final: res.finalContent.slice(0, 200),
+            },
+          };
+        },
+      });
+      expect(r.successes).toBeGreaterThanOrEqual(2);
+    },
+    600_000,
+  );
+
   // G4: Bash-decoy — shell is available but grep is the correct tool.
   it.runIf(() => available)(
     "G4 bash-decoy: prefers grep over shell for content search",

--- a/packages/read/src/index.ts
+++ b/packages/read/src/index.ts
@@ -14,7 +14,7 @@ export {
   isImageMime,
   isPdfMime,
 } from "./binary.js";
-export { streamLines } from "./lines.js";
+export { streamLines, streamLinesFromBytes } from "./lines.js";
 export { suggestSiblings } from "./suggest.js";
 export { formatText, formatDirectory, formatAttachment } from "./format.js";
 export {

--- a/packages/read/src/lines.ts
+++ b/packages/read/src/lines.ts
@@ -1,4 +1,6 @@
 import { Buffer } from "node:buffer";
+import readline from "node:readline";
+import { Readable } from "node:stream";
 import type { ReadOperations } from "@agent-sh/harness-core";
 import {
   MAX_BYTES,
@@ -27,6 +29,48 @@ export async function streamLines(
   path: string,
   opts: StreamLinesOptions,
 ): Promise<StreamLinesResult> {
+  const signalOpt: { signal?: AbortSignal } = {};
+  if (opts.signal !== undefined) signalOpt.signal = opts.signal;
+
+  const iter = ops.openLineStream(path, signalOpt);
+  return consumeLines(iter, opts);
+}
+
+/**
+ * Same line-oriented contract as {@link streamLines}, but sourced from bytes
+ * already held in memory instead of a fresh filesystem read. Lets a caller
+ * that has read the file once (e.g. for hashing) reuse those bytes for line
+ * content without a second OS read. Uses Node's own readline over an in-memory
+ * Readable so CRLF stripping, trailing-newline, and empty-file semantics match
+ * {@link ReadOperations.openLineStream} exactly.
+ */
+export async function streamLinesFromBytes(
+  bytes: Uint8Array,
+  opts: StreamLinesOptions,
+): Promise<StreamLinesResult> {
+  const str = Buffer.from(bytes).toString("utf8");
+  const rl = readline.createInterface({
+    input: Readable.from([str]),
+    crlfDelay: Infinity,
+  });
+  const signal = opts.signal;
+  const iter: AsyncIterableIterator<string> = (async function* () {
+    try {
+      for await (const line of rl) {
+        if (signal?.aborted) break;
+        yield line;
+      }
+    } finally {
+      rl.close();
+    }
+  })();
+  return consumeLines(iter, opts);
+}
+
+async function consumeLines(
+  iter: AsyncIterable<string>,
+  opts: StreamLinesOptions,
+): Promise<StreamLinesResult> {
   const maxBytes = opts.maxBytes ?? MAX_BYTES;
   const maxLineLen = opts.maxLineLength ?? MAX_LINE_LENGTH;
   const start = opts.offset - 1;
@@ -36,11 +80,6 @@ export async function streamLines(
   let totalLines = 0;
   let more = false;
   let byteCap = false;
-
-  const signalOpt: { signal?: AbortSignal } = {};
-  if (opts.signal !== undefined) signalOpt.signal = opts.signal;
-
-  const iter = ops.openLineStream(path, signalOpt);
 
   for await (const raw of iter) {
     totalLines += 1;

--- a/packages/read/src/read.ts
+++ b/packages/read/src/read.ts
@@ -21,7 +21,7 @@ import {
   formatDirectory,
   formatText,
 } from "./format.js";
-import { streamLines } from "./lines.js";
+import { streamLinesFromBytes } from "./lines.js";
 import { safeParseReadParams } from "./schema.js";
 import { suggestSiblings } from "./suggest.js";
 import type {
@@ -102,12 +102,6 @@ async function fencePath(
     permissions.bypassWorkspaceGuard !== true &&
     permissions.hook === undefined
   ) {
-    if (process.env.E2E_DEBUG_PERMISSIONS) {
-      // eslint-disable-next-line no-console
-      console.error(
-        `[read fencePath] OUTSIDE_WORKSPACE reject: resolvedPath=${JSON.stringify(resolvedPath)} roots=${JSON.stringify(permissions.roots)}`,
-      );
-    }
     return toolError(
       "OUTSIDE_WORKSPACE",
       `Path is outside all configured workspace roots: ${resolvedPath}`,
@@ -327,6 +321,9 @@ async function readText(
     }
   }
 
+  const bytes = await ops.readFile(resolvedPath);
+  const sha256 = createHash("sha256").update(bytes).digest("hex");
+
   const lineStreamOpts: {
     offset: number;
     limit: number;
@@ -339,7 +336,7 @@ async function readText(
     lineStreamOpts.maxLineLength = session.maxLineLength;
   if (session.signal !== undefined) lineStreamOpts.signal = session.signal;
 
-  const result = await streamLines(ops, resolvedPath, lineStreamOpts);
+  const result = await streamLinesFromBytes(bytes, lineStreamOpts);
 
   if (result.totalLines > 0 && offset > result.totalLines) {
     return err(
@@ -350,9 +347,6 @@ async function readText(
       ),
     );
   }
-
-  const bytes = await ops.readFile(resolvedPath);
-  const sha256 = createHash("sha256").update(bytes).digest("hex");
 
   const output = formatText({
     path: resolvedPath,

--- a/packages/read/test/read.singleRead.test.ts
+++ b/packages/read/test/read.singleRead.test.ts
@@ -1,0 +1,114 @@
+import { Buffer } from "node:buffer";
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import type { ReadOperations } from "@agent-sh/harness-core";
+import { read } from "../src/read.js";
+import type { ReadSessionConfig } from "../src/types.js";
+
+/**
+ * Perf + correctness regression guard for finding #4 (double-read).
+ *
+ * Before the fix, a single text `read` touched the file three times:
+ *   1. readSample        -> ops.readFile        (binary sniff)
+ *   2. streamLines       -> ops.openLineStream  (line content, a SECOND OS read)
+ *   3. sha256            -> ops.readFile         (hash, a THIRD read)
+ *
+ * The fix collapses (2) and (3): readText reads the bytes ONCE and reuses
+ * them for both the sha256 and the line content via streamLinesFromBytes,
+ * so openLineStream is never opened. The binary-sniff read in readSample is
+ * a separate concern and intentionally left untouched, so a full text read
+ * now performs exactly two ops.readFile calls (sniff + content) and zero
+ * openLineStream opens. This test wraps a counting ReadOperations and asserts:
+ *   - readFile is called twice (sniff + content) — never the old three reads,
+ *   - openLineStream is never opened (the double-read is gone),
+ *   - the returned content is correct,
+ *   - the returned sha256 matches a hash computed independently.
+ */
+
+const FIXTURE = "alpha\nbeta\ngamma\n";
+const FIXTURE_BYTES = new Uint8Array(Buffer.from(FIXTURE, "utf8"));
+const PATH = "/virtual/facts.txt";
+
+interface Counts {
+  readFile: number;
+  openLineStream: number;
+}
+
+function countingOps(counts: Counts): ReadOperations {
+  return {
+    async stat() {
+      return {
+        type: "file",
+        size: FIXTURE_BYTES.byteLength,
+        mtime_ms: 1_000,
+        readonly: false,
+      };
+    },
+    async readFile() {
+      counts.readFile += 1;
+      return FIXTURE_BYTES;
+    },
+    async readDirectory() {
+      return [];
+    },
+    async readDirectoryEntries() {
+      return [];
+    },
+    async realpath(p) {
+      return p;
+    },
+    mimeType() {
+      return "text/plain";
+    },
+    openLineStream() {
+      counts.openLineStream += 1;
+      // If the fix is correct this must never be invoked for text reads.
+      throw new Error("openLineStream must not be called after single-read fix");
+    },
+  };
+}
+
+function session(ops: ReadOperations): ReadSessionConfig {
+  return {
+    cwd: "/virtual",
+    ops,
+    permissions: {
+      roots: ["/virtual"],
+      sensitivePatterns: [],
+      bypassWorkspaceGuard: true,
+    },
+  };
+}
+
+describe("read — single underlying read (finding #4 regression)", () => {
+  it("never re-streams the file: sniff + content reads only, no openLineStream", async () => {
+    const counts: Counts = { readFile: 0, openLineStream: 0 };
+    const r = await read({ path: PATH }, session(countingOps(counts)));
+
+    expect(r.kind).toBe("text");
+    if (r.kind !== "text") return;
+
+    // The whole point of the fix: the sha256 + line content share ONE read
+    // (no openLineStream, no third hash read). The binary-sniff read in
+    // readSample is a separate concern, so the total is exactly two reads.
+    expect(counts.readFile).toBe(2);
+    expect(counts.openLineStream).toBe(0);
+  });
+
+  it("returns correct content and a sha256 matching the read bytes", async () => {
+    const counts: Counts = { readFile: 0, openLineStream: 0 };
+    const r = await read({ path: PATH }, session(countingOps(counts)));
+
+    expect(r.kind).toBe("text");
+    if (r.kind !== "text") return;
+
+    expect(r.output).toContain("1: alpha");
+    expect(r.output).toContain("2: beta");
+    expect(r.output).toContain("3: gamma");
+    expect(r.meta.totalLines).toBe(3);
+    expect(r.meta.returnedLines).toBe(3);
+
+    const expected = createHash("sha256").update(FIXTURE_BYTES).digest("hex");
+    expect(r.meta.sha256).toBe(expected);
+  });
+});

--- a/packages/tools/src/pi-extension.ts
+++ b/packages/tools/src/pi-extension.ts
@@ -20,7 +20,7 @@
  */
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type, type Static, type TSchema } from "typebox";
-import { formatToolError, type PermissionPolicy, type ToolError } from "@agent-sh/harness-core";
+import { formatToolError, InMemoryLedger, type Ledger, type PermissionPolicy, type ToolError } from "@agent-sh/harness-core";
 
 // Tool functions + their definitions (for description text) + session types.
 import {
@@ -180,6 +180,12 @@ const GrepParams = Type.Object({
   ),
   case_insensitive: Type.Optional(Type.Boolean()),
   multiline: Type.Optional(Type.Boolean()),
+  fixed_strings: Type.Optional(
+    Type.Boolean({
+      description:
+        "Treat pattern as an exact literal string, not a regex (ripgrep -F). Use to search strings with metacharacters like ( ) . * { } as plain text without escaping. Default false.",
+    }),
+  ),
   context_before: Type.Optional(Type.Integer()),
   context_after: Type.Optional(Type.Integer()),
   context: Type.Optional(Type.Integer()),
@@ -287,11 +293,11 @@ function withSignal<T extends object>(base: T, signal?: AbortSignal): T {
   return signal ? { ...base, signal } : base;
 }
 
-function readSession(cwd: string, signal?: AbortSignal): ReadSessionConfig {
-  return withSignal({ cwd, permissions: fsPermissions(cwd) }, signal);
+function readSession(cwd: string, ledger: Ledger, signal?: AbortSignal): ReadSessionConfig {
+  return withSignal({ cwd, permissions: fsPermissions(cwd), ledger }, signal);
 }
-function writeSession(cwd: string, signal?: AbortSignal): WriteSessionConfig {
-  return withSignal({ cwd, permissions: fsPermissions(cwd) }, signal);
+function writeSession(cwd: string, ledger: Ledger, signal?: AbortSignal): WriteSessionConfig {
+  return withSignal({ cwd, permissions: fsPermissions(cwd), ledger }, signal);
 }
 function grepSession(cwd: string, signal?: AbortSignal): GrepSessionConfig {
   return withSignal({ cwd, permissions: fsPermissions(cwd) }, signal);
@@ -362,6 +368,12 @@ function websearchSession(signal?: AbortSignal): WebSearchSessionConfig {
 // ---------------------------------------------------------------------------
 
 export default function harnessToolsExtension(pi: ExtensionAPI): void {
+  // Single per-process ledger shared by read + write/edit/multiedit so the
+  // read-before-edit gate composes (Read records here; Edit/Write read it back).
+  // harnessToolsExtension runs once at module load; the register() closures
+  // capture this instance for the whole pi process.
+  const ledger = new InMemoryLedger();
+
   const register = <T extends TSchema>(
     name: string,
     label: string,
@@ -387,19 +399,19 @@ export default function harnessToolsExtension(pi: ExtensionAPI): void {
   };
 
   register("read", "Read", readToolDefinition.description, ReadParams, (p, cwd, signal) =>
-    read(p, readSession(cwd, signal)),
+    read(p, readSession(cwd, ledger, signal)),
   );
 
   register("write", "Write", writeToolDefinition.description, WriteParams, (p, cwd, signal) =>
-    write(p, writeSession(cwd, signal)),
+    write(p, writeSession(cwd, ledger, signal)),
   );
 
   register("edit", "Edit", editToolDefinition.description, EditParams, (p, cwd, signal) =>
-    edit(p, writeSession(cwd, signal)),
+    edit(p, writeSession(cwd, ledger, signal)),
   );
 
   register("multiedit", "MultiEdit", multieditToolDefinition.description, MultiEditParams, (p, cwd, signal) =>
-    multiEdit(p, writeSession(cwd, signal)),
+    multiEdit(p, writeSession(cwd, ledger, signal)),
   );
 
   register("grep", "Grep", grepToolDefinition.description, GrepParams, (p, cwd, signal) =>

--- a/packages/tools/test/pi-extension.ledger.test.ts
+++ b/packages/tools/test/pi-extension.ledger.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Wiring regression test for the shared per-process ledger in pi-extension.ts.
+ *
+ * The pi extension registers `read` and `edit` (plus write/multiedit) against a
+ * SINGLE InMemoryLedger created inside harnessToolsExtension(). Read records into
+ * that ledger; Edit reads it back through getLatest(). Before the fix the
+ * sessions carried NO ledger, so the read-before-edit gate (NOT_READ_THIS_SESSION)
+ * fired even right after a successful Read and the model would shell out to
+ * cat/sed instead of using Edit.
+ *
+ * This is a fast unit-style test (no model, no Ollama/Bedrock). It drives the
+ * REAL extension wiring via a minimal fake ExtensionAPI that captures each
+ * registered tool, then runs read -> edit and asserts the gate composes.
+ *
+ * Not a model-driven e2e (those live in packages/harness-e2e). Safe to run once
+ * the GPU is free.
+ */
+import { describe, expect, it } from "vitest";
+import { mkdtempSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type {
+  ExtensionAPI,
+  ExtensionContext,
+  ToolDefinition,
+} from "@mariozechner/pi-coding-agent";
+import harnessToolsExtension from "../src/pi-extension.js";
+
+type AnyTool = ToolDefinition<any, any, any>;
+
+/** Capture every tool the extension registers; stub everything else. */
+function buildExtension(): Map<string, AnyTool> {
+  const tools = new Map<string, AnyTool>();
+  const fakePi = {
+    registerTool(tool: AnyTool) {
+      tools.set(tool.name, tool);
+    },
+  } as unknown as ExtensionAPI;
+  // ONE call -> read + edit close over the same in-scope shared ledger.
+  harnessToolsExtension(fakePi);
+  return tools;
+}
+
+/** Minimal ExtensionContext: only ctx.cwd is read by the execute wrapper. */
+function makeCtx(cwd: string): ExtensionContext {
+  return { cwd } as unknown as ExtensionContext;
+}
+
+/** Extract the flattened text from a pi tool result. */
+function resultText(result: { content: ReadonlyArray<{ type: string; text?: string }> }): string {
+  return result.content
+    .map((c) => (c.type === "text" && typeof c.text === "string" ? c.text : ""))
+    .join("");
+}
+
+describe("pi-extension shared ledger — read composes with edit", () => {
+  it("edit succeeds after read because both share one ledger", async () => {
+    const tools = buildExtension();
+    const readTool = tools.get("read");
+    const editTool = tools.get("edit");
+    expect(readTool, "read tool registered").toBeTruthy();
+    expect(editTool, "edit tool registered").toBeTruthy();
+
+    const dir = mkdtempSync(path.join(tmpdir(), "pi-ledger-"));
+    const target = path.join(dir, "greeting.ts");
+    writeFileSync(target, "export const greeting = 'hello';\n");
+    const ctx = makeCtx(dir);
+
+    // 1. Read records the file into the shared ledger.
+    const readResult = await readTool!.execute("id1", { path: target }, undefined, undefined, ctx);
+    const readText = resultText(readResult);
+    expect(readText).toContain("greeting");
+    expect(readText).not.toContain("NOT_READ_THIS_SESSION");
+
+    // 2. Edit reads the SAME ledger via getLatest() -> gate passes, write applies.
+    const editResult = await editTool!.execute(
+      "id2",
+      { path: target, old_string: "hello", new_string: "hi" },
+      undefined,
+      undefined,
+      ctx,
+    );
+    const editText = resultText(editResult);
+    expect(editText).not.toContain("NOT_READ_THIS_SESSION");
+    // Edit success surface: "Edited <path>: 1 replacement (...)".
+    expect(editText).toContain("Edited");
+    expect(editText).toContain(target);
+
+    expect(readFileSync(target, "utf8")).toBe("export const greeting = 'hi';\n");
+  });
+
+  it("edit on a never-read file FAILS OPEN: proceeds with a warning (D11), not a hard deny", async () => {
+    // The read-before-edit gate fails OPEN when no permission hook is wired
+    // (Read spec D11 / CLAUDE.md #6 tool-as-friction): a model with no prior
+    // Read must not be hard-blocked into shelling out to Bash. It overwrites
+    // with a warning instead. (A wired deny-hook is the way to actually block —
+    // see the deny-hook unit tests in packages/write.)
+    const tools = buildExtension();
+    const editTool = tools.get("edit");
+    expect(editTool, "edit tool registered").toBeTruthy();
+
+    const dir = mkdtempSync(path.join(tmpdir(), "pi-ledger-"));
+    const unread = path.join(dir, "unread.ts");
+    writeFileSync(unread, "export const x = 1;\n");
+    const ctx = makeCtx(dir);
+
+    const editResult = await editTool!.execute(
+      "id3",
+      { path: unread, old_string: "1", new_string: "2" },
+      undefined,
+      undefined,
+      ctx,
+    );
+    const text = resultText(editResult);
+    // Not a hard deny.
+    expect(text).not.toContain("NOT_READ_THIS_SESSION");
+    // The edit went through and disk reflects the change.
+    expect(readFileSync(unread, "utf8")).toBe("export const x = 2;\n");
+  });
+});

--- a/packages/write/src/edit.ts
+++ b/packages/write/src/edit.ts
@@ -1,4 +1,5 @@
 import { Buffer } from "node:buffer";
+import path from "node:path";
 import {
   toolError,
   withFileLock,
@@ -66,6 +67,7 @@ async function executeEdit(
   const preflight = await preflightMutation(ops, session, resolvedPath);
   if ("error" in preflight) return err(preflight.error);
   const { existingContent, existingBytes, previousSha } = preflight;
+  const gateWarnings = preflight.warnings ?? [];
 
   const editResult = applyEdit(existingContent, {
     old_string: params.old_string,
@@ -147,6 +149,7 @@ async function executeEdit(
     });
   }
 
+  const allWarnings = [...gateWarnings, ...editResult.warnings];
   const result: TextWriteResult = {
     kind: "text",
     output: formatEditSuccess({
@@ -155,7 +158,7 @@ async function executeEdit(
       replaceAll: params.replace_all === true,
       bytesBefore: existingBytes.length,
       bytesAfter: newBytes.length,
-      warnings: editResult.warnings,
+      warnings: allWarnings,
     }),
     meta: {
       path: resolvedPath,
@@ -164,9 +167,7 @@ async function executeEdit(
       sha256: newSha,
       mtime_ms: mtime,
       previous_sha256: previousSha,
-      ...(editResult.warnings.length > 0
-        ? { warnings: editResult.warnings }
-        : {}),
+      ...(allWarnings.length > 0 ? { warnings: allWarnings } : {}),
     },
   };
   return result;
@@ -176,6 +177,7 @@ export interface PreflightOk {
   readonly existingContent: string;
   readonly existingBytes: Uint8Array;
   readonly previousSha: string;
+  readonly warnings?: readonly string[];
 }
 
 export interface PreflightErr {
@@ -258,19 +260,38 @@ export async function preflightMutation(
     };
   }
 
+  const currentSha = sha256Hex(bytes);
+  const warnings: string[] = [];
+
+  // Read-before-mutate gate. Fail-open per Read spec D11: when the file has no
+  // ledger entry (never Read this session), don't hard-deny — ask the
+  // permission hook if one is wired, deny only on an explicit deny, otherwise
+  // continue with a warning. STALE_READ stays hard, and only runs when there
+  // *is* a ledger entry to compare against.
   const ledgerEntry = session.ledger?.getLatest(resolvedPath);
   if (!ledgerEntry) {
-    return {
-      error: toolError(
-        "NOT_READ_THIS_SESSION",
-        `File has not been Read in this session: ${resolvedPath}\n\nCall Read on this path first, then retry the edit.`,
-        { meta: { path: resolvedPath } },
-      ),
-    };
-  }
-
-  const currentSha = sha256Hex(bytes);
-  if (ledgerEntry.sha256 !== currentSha) {
+    if (session.permissions.hook !== undefined) {
+      const decision = await session.permissions.hook({
+        tool: "edit",
+        path: resolvedPath,
+        action: "write_unread",
+        always_patterns: [path.dirname(resolvedPath) + "/*"],
+        metadata: { reason: "not_read_this_session" },
+      });
+      if (decision === "deny") {
+        return {
+          error: toolError(
+            "DENIED_BY_HOOK",
+            `Edit of an un-Read file denied by permission hook: ${resolvedPath}`,
+            { meta: { path: resolvedPath } },
+          ),
+        };
+      }
+    }
+    warnings.push(
+      `File was not Read in this session before editing: ${resolvedPath}. Editing blind; prefer Read first so the edit anchors on current content.`,
+    );
+  } else if (ledgerEntry.sha256 !== currentSha) {
     return {
       error: toolError(
         "STALE_READ",
@@ -291,6 +312,7 @@ export async function preflightMutation(
     existingContent: content,
     existingBytes: bytes,
     previousSha: currentSha,
+    ...(warnings.length > 0 ? { warnings } : {}),
   };
 }
 

--- a/packages/write/src/engine.ts
+++ b/packages/write/src/engine.ts
@@ -5,7 +5,7 @@ import {
   findFuzzyCandidates,
   substringBoundaryCollisions,
 } from "./matching.js";
-import { normalizeLineEndings } from "./normalize.js";
+import { detectEol, normalizeLineEndings, restoreLineEndings } from "./normalize.js";
 import {
   formatFuzzyCandidates,
   formatMatchLocations,
@@ -24,11 +24,14 @@ export interface ApplyResult {
  * feeding the result into the next edit when in a MultiEdit pipeline.
  *
  * Matching algorithm is the spec's §5.1:
+ *   - detect the file's line-ending style (CRLF vs LF) on the raw content
  *   - normalize CRLF→LF on both haystack and needle
  *   - exact substring search
  *   - 0 matches + fuzzy candidates → OLD_STRING_NOT_FOUND
  *   - ≥2 matches + replace_all false → OLD_STRING_NOT_UNIQUE
  *   - apply; on replace_all, collect substring-boundary warnings
+ *   - re-apply the original line-ending style to the returned content so a
+ *     CRLF file stays CRLF on disk (matching still happens on LF text)
  */
 export function applyEdit(
   content: string,
@@ -44,6 +47,7 @@ export function applyEdit(
     );
   }
 
+  const originalEol = detectEol(content);
   const normalizedContent = normalizeLineEndings(content);
   const normalizedOld = normalizeLineEndings(oldRaw);
   const normalizedNew = normalizeLineEndings(newRaw);
@@ -108,7 +112,7 @@ export function applyEdit(
   );
 
   return {
-    content: newContent,
+    content: restoreLineEndings(newContent, originalEol),
     replacements: targetOffsets.length,
     warnings,
   };

--- a/packages/write/src/format.ts
+++ b/packages/write/src/format.ts
@@ -5,13 +5,18 @@ export function formatWriteSuccess(opts: {
   created: boolean;
   bytesBefore: number;
   bytesAfter: number;
+  warnings?: readonly string[];
 }): string {
   const { path, created, bytesBefore, bytesAfter } = opts;
   const header = `<path>${path}</path>`;
   const summary = created
     ? `Wrote ${bytesAfter} bytes to ${path}`
     : `Overwrote ${path} (was ${bytesBefore} bytes, now ${bytesAfter} bytes, ${deltaStr(bytesBefore, bytesAfter)})`;
-  return `${header}\n<result>\n${summary}\n</result>`;
+  const lines = [summary];
+  if (opts.warnings && opts.warnings.length > 0) {
+    for (const w of opts.warnings) lines.push(`Warning: ${w}`);
+  }
+  return `${header}\n<result>\n${lines.join("\n")}\n</result>`;
 }
 
 export function formatEditSuccess(opts: {

--- a/packages/write/src/multiedit.ts
+++ b/packages/write/src/multiedit.ts
@@ -69,6 +69,7 @@ async function executeMultiEdit(
   const preflight = await preflightMutation(ops, session, resolvedPath);
   if ("error" in preflight) return err(preflight.error);
   const { existingContent, existingBytes, previousSha } = preflight;
+  const gateWarnings = preflight.warnings ?? [];
 
   const edits: EditSpec[] = params.edits.map((e) => ({
     old_string: e.old_string,
@@ -152,6 +153,7 @@ async function executeMultiEdit(
     });
   }
 
+  const allWarnings = [...gateWarnings, ...pipelineResult.warnings];
   const result: TextWriteResult = {
     kind: "text",
     output: formatMultiEditSuccess({
@@ -160,7 +162,7 @@ async function executeMultiEdit(
       totalReplacements: pipelineResult.totalReplacements,
       bytesBefore: existingBytes.length,
       bytesAfter: newBytes.length,
-      warnings: pipelineResult.warnings,
+      warnings: allWarnings,
     }),
     meta: {
       path: resolvedPath,
@@ -170,9 +172,7 @@ async function executeMultiEdit(
       sha256: newSha,
       mtime_ms: mtime,
       previous_sha256: previousSha,
-      ...(pipelineResult.warnings.length > 0
-        ? { warnings: pipelineResult.warnings }
-        : {}),
+      ...(allWarnings.length > 0 ? { warnings: allWarnings } : {}),
     },
   };
   return result;

--- a/packages/write/src/normalize.ts
+++ b/packages/write/src/normalize.ts
@@ -6,3 +6,26 @@ export function normalizeLineEndings(input: string): string {
   if (input.length === 0 || input.indexOf("\r") === -1) return input;
   return input.replace(/\r\n/g, "\n");
 }
+
+/** Line-ending style detected on the *unnormalized* file content. */
+export type Eol = "crlf" | "lf";
+
+/**
+ * Detect the dominant line ending on raw (unnormalized) input. Any CRLF
+ * present marks the file as `crlf`; otherwise `lf`. Used so Edit/MultiEdit can
+ * re-apply the original style after matching is done on LF-normalized text.
+ */
+export function detectEol(input: string): Eol {
+  return input.indexOf("\r\n") === -1 ? "lf" : "crlf";
+}
+
+/**
+ * Re-apply the original line-ending style to LF-normalized content. `lf` is
+ * assumed CR-free (it came out of the LF-normalized matching pipeline), so for
+ * `crlf` we can safely turn every bare LF back into CRLF. For `lf` the content
+ * is returned untouched.
+ */
+export function restoreLineEndings(lf: string, eol: Eol): string {
+  if (eol === "lf" || lf.indexOf("\n") === -1) return lf;
+  return lf.replace(/\n/g, "\r\n");
+}

--- a/packages/write/src/schema.ts
+++ b/packages/write/src/schema.ts
@@ -67,7 +67,7 @@ export const WRITE_TOOL_DESCRIPTION = `Create a new file, or overwrite an existi
 
 Usage:
 - New file (path does not exist): call Write directly. No prior Read is required.
-- Existing file: you must Read it first in this session, or Write fails with NOT_READ_THIS_SESSION. This protects against clobbering unseen content.
+- Existing file: Read it first in this session. Overwriting an un-Read file still succeeds but returns a Warning (and may prompt a permission hook); if the file changed on disk since your Read, Write fails with STALE_READ. Reading first protects against clobbering unseen content.
 - Prefer Edit or MultiEdit for targeted changes to existing files. Use Write only for new files or genuine wholesale rewrites.
 - Write is atomic: bytes land via a temporary file + rename, so readers either see the old content or the new content, never partial.
 - Binary content is allowed (pass bytes encoded as the content string); the tool does not inspect content for text-ness.
@@ -76,12 +76,12 @@ Usage:
 export const EDIT_TOOL_DESCRIPTION = `Replace exactly one occurrence of old_string with new_string in a file.
 
 Usage:
-- The file must have been Read first in this session. Edit refuses if there is no ledger entry for the path, or if the file has changed on disk since the Read (STALE_READ).
+- Read the file first in this session. Editing an un-Read file still succeeds but returns a Warning (and may prompt a permission hook). If the file changed on disk since the Read, Edit fails with STALE_READ.
 - old_string must match the file content exactly, character for character, including whitespace and indentation.
 - If old_string appears more than once, the call fails with OLD_STRING_NOT_UNIQUE and lists every match location. Widen old_string with surrounding context until unique, or pass replace_all: true for rename-style changes.
 - If old_string does not match, the call fails with OLD_STRING_NOT_FOUND and returns the top fuzzy candidates with line numbers so you can correct the string and retry.
 - Use dry_run: true to preview the unified diff without writing.
-- CRLF is normalized to LF on both sides; tabs and other whitespace are exact.
+- Line endings are normalized to LF for matching, so old_string may use LF even when the file is CRLF; the file's original CRLF/LF style is preserved on disk. Tabs and other whitespace are exact.
 - Edits on binary files or notebooks are refused.`;
 
 export const MULTIEDIT_TOOL_DESCRIPTION = `Apply a sequence of edits to a single file atomically.
@@ -90,7 +90,7 @@ Usage:
 - edits is an ordered list of { old_string, new_string, replace_all? } objects.
 - Edits apply sequentially in memory: later edits see the output of earlier edits. This lets you rename a function and then change its signature in one call.
 - If any edit fails (no match, non-unique without replace_all, no-op, etc.), none of the edits are applied and the file is untouched.
-- The file must have been Read first in this session, and must not have changed on disk since the Read.
+- Read the file first in this session. Editing an un-Read file still succeeds but returns a Warning (and may prompt a permission hook). If the file changed on disk since the Read, the call fails with STALE_READ.
 - Use dry_run: true to preview the final unified diff without writing.`;
 
 export const writeToolDefinition: ToolDefinition = {

--- a/packages/write/src/types.ts
+++ b/packages/write/src/types.ts
@@ -83,6 +83,7 @@ export interface WriteMeta {
   readonly mtime_ms: number;
   readonly created: boolean;
   readonly previous_sha256?: string;
+  readonly warnings?: readonly string[];
 }
 
 export interface EditMeta {

--- a/packages/write/src/write.ts
+++ b/packages/write/src/write.ts
@@ -1,4 +1,5 @@
 import { Buffer } from "node:buffer";
+import path from "node:path";
 import {
   toolError,
   withFileLock,
@@ -65,6 +66,7 @@ async function executeWrite(
   const exists = stat !== undefined && stat.type === "file";
   let previousSha: string | undefined;
   let previousBytes = 0;
+  let gateWarning: string | undefined;
 
   if (stat !== undefined && stat.type === "directory") {
     return err(
@@ -90,17 +92,32 @@ async function executeWrite(
     previousBytes = existingBytes.length;
     previousSha = sha256Hex(existingBytes);
 
+    // Read-before-overwrite gate. Fail-open per Read spec D11: when the file
+    // has no ledger entry, don't hard-deny — ask the permission hook if one is
+    // wired, deny only on an explicit deny, otherwise overwrite with a
+    // warning. STALE_READ stays hard and only runs when a ledger entry exists.
     const ledgerEntry = session.ledger?.getLatest(resolvedPath);
     if (!ledgerEntry) {
-      return err(
-        toolError(
-          "NOT_READ_THIS_SESSION",
-          `Write refuses to overwrite a file that has not been Read in this session: ${resolvedPath}\n\nCall Read on this path first, then retry Write.`,
-          { meta: { path: resolvedPath } },
-        ),
-      );
-    }
-    if (ledgerEntry.sha256 !== previousSha) {
+      if (session.permissions.hook !== undefined) {
+        const decision = await session.permissions.hook({
+          tool: "write",
+          path: resolvedPath,
+          action: "write_unread",
+          always_patterns: [path.dirname(resolvedPath) + "/*"],
+          metadata: { reason: "not_read_this_session" },
+        });
+        if (decision === "deny") {
+          return err(
+            toolError(
+              "DENIED_BY_HOOK",
+              `Overwrite of an un-Read file denied by permission hook: ${resolvedPath}`,
+              { meta: { path: resolvedPath } },
+            ),
+          );
+        }
+      }
+      gateWarning = `File was not Read in this session before overwriting: ${resolvedPath}. Overwriting blind; prefer Read first so you don't discard unseen changes.`;
+    } else if (ledgerEntry.sha256 !== previousSha) {
       return err(
         toolError(
           "STALE_READ",
@@ -180,11 +197,13 @@ async function executeWrite(
     });
   }
 
+  const warnings = gateWarning !== undefined ? [gateWarning] : [];
   const output = formatWriteSuccess({
     path: resolvedPath,
     created: !exists,
     bytesBefore: previousBytes,
     bytesAfter: bytes.length,
+    warnings,
   });
 
   const result: TextWriteResult = {
@@ -197,6 +216,7 @@ async function executeWrite(
       mtime_ms: mtime,
       created: !exists,
       ...(previousSha !== undefined ? { previous_sha256: previousSha } : {}),
+      ...(warnings.length > 0 ? { warnings } : {}),
     },
   };
   return result;

--- a/packages/write/test/edit.test.ts
+++ b/packages/write/test/edit.test.ts
@@ -29,17 +29,64 @@ describe("edit — golden path", () => {
   });
 });
 
-describe("edit — ledger gate", () => {
-  it("refuses without a Read", async () => {
+describe("edit — read-before-mutate gate (fail-open)", () => {
+  it("edits an un-Read file (no hook): succeeds with a warning, applies change", async () => {
     const dir = makeTempDir();
     const target = writeFixture(dir, "a.txt", "hi\n");
     const r = await edit(
       { path: target, old_string: "hi", new_string: "bye" },
       makeSession(dir),
     );
+    expect(r.kind).toBe("text");
+    if (r.kind !== "text") return;
+    // The change lands despite no prior Read.
+    expect(readFileUtf8(target)).toBe("bye\n");
+    // The warning surfaces in both output and meta (it's model-facing).
+    expect(r.output).toContain("Warning:");
+    expect(r.output).toContain("not Read in this session");
+    expect(r.meta).toHaveProperty("warnings");
+    if (!("warnings" in r.meta)) return;
+    expect(r.meta.warnings?.[0]).toContain("not Read in this session");
+  });
+
+  it("edits an un-Read file when the permission hook allows", async () => {
+    const dir = makeTempDir();
+    const target = writeFixture(dir, "a.txt", "hi\n");
+    const session = makeSession(dir, {
+      permissions: {
+        roots: [dir],
+        sensitivePatterns: [],
+        hook: async () => "allow",
+      },
+    });
+    const r = await edit(
+      { path: target, old_string: "hi", new_string: "bye" },
+      session,
+    );
+    expect(r.kind).toBe("text");
+    if (r.kind !== "text") return;
+    expect(readFileUtf8(target)).toBe("bye\n");
+  });
+
+  it("refuses an un-Read file when the permission hook denies", async () => {
+    const dir = makeTempDir();
+    const target = writeFixture(dir, "a.txt", "hi\n");
+    const session = makeSession(dir, {
+      permissions: {
+        roots: [dir],
+        sensitivePatterns: [],
+        hook: async () => "deny",
+      },
+    });
+    const r = await edit(
+      { path: target, old_string: "hi", new_string: "bye" },
+      session,
+    );
     expect(r.kind).toBe("error");
     if (r.kind !== "error") return;
-    expect(r.error.code).toBe("NOT_READ_THIS_SESSION");
+    expect(r.error.code).toBe("DENIED_BY_HOOK");
+    // File is untouched on a deny.
+    expect(readFileUtf8(target)).toBe("hi\n");
   });
 
   it("refuses stale reads", async () => {
@@ -170,7 +217,7 @@ describe("edit — dry_run", () => {
 });
 
 describe("edit — CRLF normalization", () => {
-  it("matches LF old_string against CRLF content and preserves LF in output", async () => {
+  it("matches LF old_string against CRLF content and preserves CRLF in output", async () => {
     const dir = makeTempDir();
     const target = writeFixture(dir, "win.txt", "a\r\nb\r\nc\r\n");
     const session = makeSession(dir);
@@ -180,7 +227,8 @@ describe("edit — CRLF normalization", () => {
       session,
     );
     expect(r.kind).toBe("text");
-    expect(readFileUtf8(target)).toBe("a\nB\nc\n");
+    // CRLF style survives: the on-disk file is still Windows-terminated.
+    expect(readFileUtf8(target)).toBe("a\r\nB\r\nc\r\n");
   });
 });
 

--- a/packages/write/test/engine.test.ts
+++ b/packages/write/test/engine.test.ts
@@ -79,13 +79,24 @@ describe("engine — applyEdit", () => {
     expect(r.code).toBe("EMPTY_FILE");
   });
 
-  it("normalizes CRLF on both needle and haystack", () => {
+  it("matches on LF but preserves CRLF line endings in the output", () => {
     const r = applyEdit("a\r\nb\r\nc\r\n", {
       old_string: "b\nc",
       new_string: "B\nC",
     });
     if ("code" in r) throw new Error(`unexpected error: ${r.code}`);
+    // Needle uses LF; haystack is CRLF; the file's CRLF style survives.
+    expect(r.content).toBe("a\r\nB\r\nC\r\n");
+  });
+
+  it("keeps LF files LF (no stray CR introduced)", () => {
+    const r = applyEdit("a\nb\nc\n", {
+      old_string: "b\nc",
+      new_string: "B\nC",
+    });
+    if ("code" in r) throw new Error(`unexpected error: ${r.code}`);
     expect(r.content).toBe("a\nB\nC\n");
+    expect(r.content).not.toContain("\r");
   });
 });
 

--- a/packages/write/test/multiedit.test.ts
+++ b/packages/write/test/multiedit.test.ts
@@ -109,6 +109,51 @@ describe("multiEdit — dry_run", () => {
   });
 });
 
+describe("multiEdit — read-before-mutate gate (fail-open)", () => {
+  it("edits an un-Read file (no hook): succeeds with a gate warning", async () => {
+    const dir = makeTempDir();
+    const target = writeFixture(dir, "a.txt", "x\ny\n");
+    const r = await multiEdit(
+      {
+        path: target,
+        edits: [
+          { old_string: "x", new_string: "X" },
+          { old_string: "y", new_string: "Y" },
+        ],
+      },
+      makeSession(dir),
+    );
+    expect(r.kind).toBe("text");
+    if (r.kind !== "text") return;
+    expect(readFileUtf8(target)).toBe("X\nY\n");
+    expect(r.output).toContain("Warning:");
+    expect(r.output).toContain("not Read in this session");
+    expect(r.meta).toHaveProperty("warnings");
+    if (!("warnings" in r.meta)) return;
+    expect(r.meta.warnings?.[0]).toContain("not Read in this session");
+  });
+
+  it("refuses an un-Read file when the permission hook denies", async () => {
+    const dir = makeTempDir();
+    const target = writeFixture(dir, "a.txt", "x\n");
+    const session = makeSession(dir, {
+      permissions: {
+        roots: [dir],
+        sensitivePatterns: [],
+        hook: async () => "deny",
+      },
+    });
+    const r = await multiEdit(
+      { path: target, edits: [{ old_string: "x", new_string: "X" }] },
+      session,
+    );
+    expect(r.kind).toBe("error");
+    if (r.kind !== "error") return;
+    expect(r.error.code).toBe("DENIED_BY_HOOK");
+    expect(readFileUtf8(target)).toBe("x\n");
+  });
+});
+
 describe("multiEdit — rejects empty edits array", () => {
   it("fails schema validation", async () => {
     const dir = makeTempDir();

--- a/packages/write/test/write.test.ts
+++ b/packages/write/test/write.test.ts
@@ -66,17 +66,63 @@ describe("write — create new file", () => {
   });
 });
 
-describe("write — overwrite existing file", () => {
-  it("refuses to overwrite a file that has not been Read", async () => {
+describe("write — overwrite existing file (fail-open gate)", () => {
+  it("overwrites an un-Read file (no hook): succeeds with a warning", async () => {
     const dir = makeTempDir();
     const target = writeFixture(dir, "existing.txt", "old content\n");
     const r = await write(
       { path: target, content: "new content\n" },
       makeSession(dir),
     );
+    expect(r.kind).toBe("text");
+    if (r.kind !== "text") return;
+    expect(readFileUtf8(target)).toBe("new content\n");
+    expect(r.meta.created).toBe(false);
+    // Warning surfaces in output and meta.
+    expect(r.output).toContain("Warning:");
+    expect(r.output).toContain("not Read in this session");
+    expect(r.meta).toHaveProperty("warnings");
+    expect(r.meta.warnings?.[0]).toContain("not Read in this session");
+  });
+
+  it("overwrites an un-Read file when the permission hook allows", async () => {
+    const dir = makeTempDir();
+    const target = writeFixture(dir, "existing.txt", "old content\n");
+    const session = makeSession(dir, {
+      permissions: {
+        roots: [dir],
+        sensitivePatterns: [],
+        hook: async () => "allow",
+      },
+    });
+    const r = await write(
+      { path: target, content: "new content\n" },
+      session,
+    );
+    expect(r.kind).toBe("text");
+    if (r.kind !== "text") return;
+    expect(readFileUtf8(target)).toBe("new content\n");
+  });
+
+  it("refuses to overwrite an un-Read file when the permission hook denies", async () => {
+    const dir = makeTempDir();
+    const target = writeFixture(dir, "existing.txt", "old content\n");
+    const session = makeSession(dir, {
+      permissions: {
+        roots: [dir],
+        sensitivePatterns: [],
+        hook: async () => "deny",
+      },
+    });
+    const r = await write(
+      { path: target, content: "new content\n" },
+      session,
+    );
     expect(r.kind).toBe("error");
     if (r.kind !== "error") return;
-    expect(r.error.code).toBe("NOT_READ_THIS_SESSION");
+    expect(r.error.code).toBe("DENIED_BY_HOOK");
+    // File is untouched on a deny.
+    expect(readFileUtf8(target)).toBe("old content\n");
   });
 
   it("refuses when ledger sha is stale", async () => {


### PR DESCRIPTION
Fixes for failure modes surfaced by driving the tools with a real model (Qwen3.6-27B) in a live agent session — chiefly the model abandoning the dedicated tools and shelling out to `cat`/`sed`.

## Fixes

**tools — shared ledger (the root cause of shell fallback)**
`readSession()`/`writeSession()` returned `{ cwd, permissions }` with no ledger, so Read recorded nothing and every Edit/Write hit `NOT_READ_THIS_SESSION` → hard deny → model routed to Bash. `harnessToolsExtension()` runs once at load, so a single `InMemoryLedger` in that scope is process-lived and shared between read and write/edit/multiedit. Gate now works as designed.

**write — CRLF/BOM preservation (correctness bug)**
Edits matched on CRLF→LF-normalized content but wrote the normalized (LF) bytes back, silently converting CRLF files to LF on a single edit. Now detect original EOL+BOM and restore on output; matching stays normalized.

**write — fail-open read gate (D11)**
No-ledger-entry case hard-denied (`NOT_READ_THIS_SESSION`). Per Read spec D11 ("rails fail open to the hook, not hard-deny"), it now asks the permission hook (deny only on explicit deny) or proceeds with a warning when no hook is wired. `STALE_READ` stays a hard, actionable error.

**read — single read + cruft**
`readText()` read the file twice (stream for content, second `readFile` for sha). Now one read feeds both. Removed env-gated debug `console.error` from shipped source.

**grep — fixed_strings literal search**
Regex-only forced hand-escaping for `foo(bar)` / `a.b.c`. Adds `fixed_strings` (ripgrep `-F`), skips the regex compile-probe; `INVALID_REGEX` hint points to it.

**bash — network-call steer**
Description now names stalling network calls (curl/wget) alongside servers/watchers → `background: true` or explicit client timeout. Description-only.

**harness-e2e — OpenAI backend**
`E2E_BACKEND=openai` drives suites against an OpenAI `/v1` server (local llama.cpp), used to validate all of the above against Qwen3.6-27B.

## Validation
- `build` + `typecheck` + `test` green locally (matches CI; e2e excluded as in CI).
- Unit: read 41, grep 40, write 62, bash 39, tools 2 — all pass.
- e2e vs Qwen3.6-27B (via the new openai backend): write.e2e.hard 8/8 (incl. W8 bash-decoy `shell:0`, W2 read-gate recovery), grep 9/9 (incl. G3b fixed-strings), CRLF e2e, read.
- Integration: a 5-file rename task through pi → all edits via the `edit` tool, zero shell fallback.

🤖 AI-assisted; design and implementation reviewed and owned by me.