### PR TITLE
feat: persistent background job store, ignore_whitespace edits, batch tool, security hardening

### DIFF
--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -51,6 +51,7 @@ jobs:
             harness-grep
             harness-glob
             harness-bash
+            harness-batch
             harness-webfetch
             harness-websearch
             harness-lsp

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,6 +498,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "globset"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,6 +610,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "harness-batch"
+version = "0.1.0"
+dependencies = [
+ "glob",
+ "harness-core",
+ "regex",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "harness-core"
 version = "0.1.0"
 dependencies = [
@@ -695,6 +714,7 @@ name = "harness-tools"
 version = "0.1.2"
 dependencies = [
  "harness-bash",
+ "harness-batch",
  "harness-core",
  "harness-glob",
  "harness-grep",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/grep",
     "crates/glob",
     "crates/bash",
+    "crates/batch",
     "crates/webfetch",
     "crates/websearch",
     "crates/read",
@@ -40,3 +41,9 @@ globset = "0.4"
 
 # Test deps
 tempfile = "3"
+
+[profile.release]
+codegen-units = 1
+opt-level = 3
+lto = "fat"
+

--- a/crates/bash/src/constants.rs
+++ b/crates/bash/src/constants.rs
@@ -5,6 +5,9 @@ pub const MAX_OUTPUT_BYTES_INLINE: usize = 30_720;
 pub const MAX_OUTPUT_BYTES_FILE: usize = 10 * 1024 * 1024;
 pub const BACKGROUND_MAX_JOBS: usize = 16;
 pub const KILL_GRACE_MS: u64 = 5_000;
+/// TTL for completed background jobs (7 days). After this, metadata is
+/// pruned on next executor creation or explicit cleanup.
+pub const BACKGROUND_JOB_TTL_SECS: u64 = 7 * 24 * 60 * 60;
 
 /// Env var prefixes the tool refuses to let the model set. Mirrors the
 /// TS `SENSITIVE_ENV_PREFIXES` list.

--- a/crates/bash/src/executor.rs
+++ b/crates/bash/src/executor.rs
@@ -8,7 +8,7 @@ use tokio::io::{AsyncReadExt, BufReader};
 use tokio::process::{Child, Command};
 use tokio::sync::oneshot;
 
-use crate::constants::KILL_GRACE_MS;
+use crate::constants::{BACKGROUND_JOB_TTL_SECS, KILL_GRACE_MS};
 
 /// Everything the runtime needs to launch + wire up a subprocess. The
 /// `on_stdout`/`on_stderr` callbacks hand each chunk back to the
@@ -61,6 +61,20 @@ pub trait BashExecutor: Send + Sync {
     async fn close_session(&self);
 }
 
+/// Persistent metadata for a background job, serialized to disk so
+/// completed jobs survive executor recreation.
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
+struct JobMetadata {
+    out_path: String,
+    err_path: String,
+    running: bool,
+    exit_code: Option<i32>,
+    created_at: u64,
+    /// Workspace root for scoping; only jobs from the same workspace are
+    /// restored, preventing cross-workspace output leakage.
+    workspace_root: String,
+}
+
 /// Background job state kept in-process. Stdout/stderr go to temp files
 /// keyed by job_id; `read_background` reads a window into each by byte
 /// offset.
@@ -72,21 +86,98 @@ struct Job {
     /// Handle so `kill_background` can signal via tokio's process APIs
     /// rather than raw PIDs (the child stays attached until exit).
     child: Option<Arc<Mutex<Child>>>,
+    /// True if this job was restored from disk and has no child handle.
+    /// Restored jobs should refresh their metadata on each poll.
+    restored: bool,
 }
 
 pub struct LocalBashExecutor {
     log_dir: PathBuf,
-    jobs: Arc<tokio::sync::Mutex<HashMap<String, Arc<tokio::sync::Mutex<Job>>>>>,
+    /// Workspace root used to scope job restoration. Only jobs whose
+    /// metadata workspace_root matches this are restored on startup.
+    workspace_root: String,
+    /// Outer std::sync::Mutex avoids tokio blocking_lock issues during
+    /// construction. The inner tokio::sync::Mutex<Job> handles async access.
+    jobs: Arc<std::sync::Mutex<HashMap<String, Arc<tokio::sync::Mutex<Job>>>>>,
 }
 
 impl LocalBashExecutor {
     pub fn new() -> Self {
+        // Derive workspace root from current working directory for scoping.
+        let workspace_root = std::env::current_dir()
+            .ok()
+            .and_then(|p| p.canonicalize().ok())
+            .unwrap_or_else(|| PathBuf::from("unknown"));
+        let workspace_root = workspace_root.to_string_lossy().to_string();
         let log_dir = std::env::temp_dir().join("agent-sh-bash-logs");
         std::fs::create_dir_all(&log_dir).ok();
-        Self {
-            log_dir,
-            jobs: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
+        let mut self_ = Self {
+            log_dir: log_dir.clone(),
+            workspace_root: workspace_root.clone(),
+            jobs: Arc::new(std::sync::Mutex::new(HashMap::new())),
+        };
+        // Load existing job metadata from disk (completed jobs from previous sessions).
+        self_.load_jobs_from_disk().ok();
+        self_
+    }
+
+    /// Restore completed jobs from disk so they remain queryable across
+    /// executor recreations. Prunes jobs older than the TTL.
+    /// Only restores jobs that match the current workspace_root to prevent
+    /// cross-workspace job leakage.
+    fn load_jobs_from_disk(&mut self) -> Result<(), String> {
+        let meta_dir = self.log_dir.join("job-meta");
+        if !meta_dir.exists() {
+            return Ok(());
         }
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+
+        for entry in std::fs::read_dir(&meta_dir).map_err(|e| e.to_string())? {
+            let entry = entry.map_err(|e| e.to_string())?;
+            let path = entry.path();
+            if !path.extension().map_or(false, |e| e == "json") {
+                continue;
+            }
+            let meta: JobMetadata = match serde_json::from_slice(
+                &std::fs::read(&path).map_err(|e| e.to_string())?,
+            ) {
+                Ok(m) => m,
+                Err(_) => continue,
+            };
+            // Prune expired jobs.
+            if now.saturating_sub(meta.created_at) > BACKGROUND_JOB_TTL_SECS {
+                let _ = std::fs::remove_file(&path);
+                let _ = std::fs::remove_file(&PathBuf::from(&meta.out_path));
+                let _ = std::fs::remove_file(&PathBuf::from(&meta.err_path));
+                continue;
+            }
+            // Only restore jobs from the current workspace.
+            if meta.workspace_root != self.workspace_root {
+                continue;
+            }
+            // Restore job with its persisted running state. Running jobs won't have
+            // a child handle (old executor died), but callers can still poll
+            // log files; when the child exits, the waiter writes final metadata.
+            let job = Arc::new(tokio::sync::Mutex::new(Job {
+                out_path: PathBuf::from(meta.out_path),
+                err_path: PathBuf::from(meta.err_path),
+                running: meta.running,
+                exit_code: if meta.running { None } else { meta.exit_code },
+                child: None,
+                restored: true,
+            }));
+            let job_id = path.file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("")
+                .to_string();
+            if !job_id.is_empty() {
+                self.jobs.lock().unwrap().insert(job_id, job);
+            }
+        }
+        Ok(())
     }
 }
 
@@ -231,11 +322,21 @@ impl BashExecutor for LocalBashExecutor {
             running: true,
             exit_code: None,
             child: Some(Arc::new(Mutex::new(child))),
+            restored: false,
         }));
         {
-            let mut jobs = self.jobs.lock().await;
+            let mut jobs = self.jobs.lock().unwrap();
             jobs.insert(job_id.clone(), Arc::clone(&job));
         }
+        // Persist metadata immediately so in-flight jobs survive executor
+        // recreation. The waiter below will overwrite with final status.
+        // Canonicalize cwd before persisting so the workspace_root comparison
+        // at restore time matches the canonicalized self.workspace_root.
+        let g = job.lock().await;
+        let canonicalized_cwd = std::fs::canonicalize(&cwd)
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_else(|_| cwd.clone());
+        persist_job_metadata(&self.log_dir, &job_id, &*g, &canonicalized_cwd);
 
         // Pipe stdout → file
         let out_path_spawn = out_path.clone();
@@ -281,13 +382,18 @@ impl BashExecutor for LocalBashExecutor {
 
         // Wait for exit in the background and record it.
         let job_watch = Arc::clone(&job);
+        let log_dir = self.log_dir.clone();
+        let job_id_clone = job_id.clone();
+        let workspace_root = canonicalized_cwd.clone();
         tokio::spawn(async move {
             let child_arc = {
                 let j = job_watch.lock().await;
                 j.child.clone()
             };
             if let Some(child_arc) = child_arc {
-                // Take the child out of the Arc<Mutex> so we can .wait() on it.
+                // Take the child out of the Arc<Mutex<>> so we can .wait() on it.
+                // Use std::mem::replace with a placeholder — the sentinel is
+                // immediately replaced out so it never blocks.
                 let mut child_opt: Option<Child> = {
                     let mut guard = child_arc.lock().unwrap();
                     Some(std::mem::replace(&mut *guard, spawn_sentinel()))
@@ -301,6 +407,8 @@ impl BashExecutor for LocalBashExecutor {
                         Err(_) => None,
                     };
                     j.child = None;
+                    // Persist job metadata to disk for cross-session queries.
+                    let _ = persist_job_metadata(&log_dir, &job_id_clone, &j, &workspace_root);
                 }
             }
         });
@@ -315,21 +423,49 @@ impl BashExecutor for LocalBashExecutor {
         head_limit: usize,
     ) -> Result<BackgroundReadResult, String> {
         let job = {
-            let jobs = self.jobs.lock().await;
+            let jobs = self.jobs.lock().unwrap();
             jobs.get(job_id).cloned()
         };
         let job = match job {
             Some(j) => j,
             None => return Err(format!("Unknown job_id: {}", job_id)),
         };
-        let (out_path, err_path, running, exit_code) = {
+        let (out_path, err_path, running, exit_code, restored) = {
             let g = job.lock().await;
             (
                 g.out_path.clone(),
                 g.err_path.clone(),
                 g.running,
                 g.exit_code,
+                g.restored,
             )
+        };
+        // For restored jobs (no child handle), reload metadata from disk
+        // so that completed jobs are detected even if this executor
+        // didn't spawn the original child.
+        let (running, exit_code) = if restored && running {
+            let meta_path = self.log_dir.join("job-meta").join(format!("{}.json", job_id));
+            match std::fs::read_to_string(&meta_path) {
+                Ok(data) => {
+                    match serde_json::from_str::<JobMetadata>(&data) {
+                        Ok(meta) => {
+                            // Update in-memory state to match disk.
+                            {
+                                let mut g = job.lock().await;
+                                g.running = meta.running;
+                                if !meta.running {
+                                    g.exit_code = meta.exit_code;
+                                }
+                            }
+                            (meta.running, if meta.running { None } else { meta.exit_code })
+                        }
+                        Err(_) => (running, exit_code),
+                    }
+                }
+                Err(_) => (running, exit_code),
+            }
+        } else {
+            (running, exit_code)
         };
         let (out_text, out_total) = read_slice(&out_path, since_byte, head_limit);
         let (err_text, err_total) = read_slice(&err_path, since_byte, head_limit);
@@ -345,17 +481,25 @@ impl BashExecutor for LocalBashExecutor {
 
     async fn kill_background(&self, job_id: &str, _signal: &str) -> Result<(), String> {
         let job = {
-            let jobs = self.jobs.lock().await;
+            let jobs = self.jobs.lock().unwrap();
             jobs.get(job_id).cloned()
         };
         let job = match job {
             Some(j) => j,
             None => return Err(format!("Unknown job_id: {}", job_id)),
         };
-        let child_arc = {
+        let (child_arc, restored) = {
             let g = job.lock().await;
-            g.child.clone()
+            (g.child.clone(), g.restored)
         };
+        if restored && child_arc.is_none() {
+            return Err(
+                "Cannot kill restored background job: the original process handle \
+                 was lost when this executor session started. The job may have \
+                 already exited or may still be running with no way to signal it."
+                    .to_string(),
+            );
+        }
         if let Some(child_arc) = child_arc {
             let mut guard = child_arc.lock().unwrap();
             // start_kill sends SIGKILL on unix. SIGTERM vs SIGKILL
@@ -367,8 +511,14 @@ impl BashExecutor for LocalBashExecutor {
     }
 
     async fn close_session(&self) {
-        let mut jobs = self.jobs.lock().await;
-        for (_, job) in jobs.drain() {
+        // Collect job Arcs while holding the lock, then drop it before
+        // awaiting on each job to avoid holding std::sync::MutexGuard
+        // across an await point.
+        let jobs: Vec<_> = {
+            let mut guard = self.jobs.lock().unwrap();
+            guard.drain().map(|(_, job)| job).collect()
+        };
+        for job in jobs {
             let child_arc = {
                 let g = job.lock().await;
                 g.child.clone()
@@ -442,17 +592,43 @@ fn signal_name(status: &std::process::ExitStatus) -> Option<String> {
     }
 }
 
-/// Placeholder child for std::mem::replace. This panics on drop if
-/// actually used, which is fine because we only `std::mem::replace` it
-/// out during cleanup; it never gets .wait()'d.
+/// Placeholder child for std::mem::replace. Immediately killed on drop via
+/// `kill_on_drop(true)` so it never becomes a zombie. We never .wait() on
+/// this — it's only used as a temporary value during `std::mem::replace`.
 fn spawn_sentinel() -> Child {
-    // A lazily-failing child: immediately-failing shell invocation.
-    // We never .wait on this — it's only used as a placeholder value.
     let mut cmd = Command::new("/bin/true");
     cmd.stdin(Stdio::null());
     cmd.stdout(Stdio::null());
     cmd.stderr(Stdio::null());
+    cmd.kill_on_drop(true);
     cmd.spawn().expect("/bin/true should always spawn")
+}
+
+/// Serialize job metadata to disk so completed jobs survive executor
+/// recreation. Idempotent — safe to call multiple times for the same job.
+fn persist_job_metadata(log_dir: &PathBuf, job_id: &str, job: &Job, workspace_root: &str) {
+    let meta_dir = log_dir.join("job-meta");
+    if std::fs::create_dir_all(&meta_dir).is_err() {
+        return;
+    }
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let meta = JobMetadata {
+        out_path: job.out_path.to_string_lossy().into_owned(),
+        err_path: job.err_path.to_string_lossy().into_owned(),
+        running: job.running,
+        exit_code: job.exit_code,
+        created_at: now,
+        workspace_root: workspace_root.to_string(),
+    };
+    let bytes = match serde_json::to_string(&meta) {
+        Ok(b) => b,
+        Err(_) => return,
+    };
+    let path = meta_dir.join(format!("{}.json", job_id));
+    let _ = std::fs::write(&path, &bytes);
 }
 
 /// Minimal UUID-v4-ish generator to avoid pulling the `uuid` crate just

--- a/crates/batch/Cargo.toml
+++ b/crates/batch/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "harness-batch"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+harness-core = { path = "../harness-core", version = "0.1.0" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+glob = "0.3"
+regex = "1"

--- a/crates/batch/src/lib.rs
+++ b/crates/batch/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod schema;
+pub mod run;

--- a/crates/batch/src/run.rs
+++ b/crates/batch/src/run.rs
@@ -1,0 +1,459 @@
+use std::process::Stdio;
+
+use harness_core::{ToolError, ToolErrorCode};
+
+use crate::schema::{BatchMode, BatchParams, BatchTarget};
+
+/// Result for a single target execution.
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
+pub struct TargetResult {
+    pub path: String,
+    pub status: BatchStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stdout: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stderr: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub enum BatchStatus {
+    Success,
+    Failed { exit_code: i32 },
+    TimedOut,
+    Skipped,
+}
+
+/// Resolves targets from the batch params.
+fn resolve_targets(targets: &BatchTarget) -> Result<Vec<String>, String> {
+    match targets {
+        BatchTarget::Subdirs { path, name_filter } => {
+            let root = std::path::Path::new(path);
+            if !root.is_dir() {
+                return Err(format!("Not a directory: {}", path));
+            }
+            let mut results = Vec::new();
+            for entry in std::fs::read_dir(root).map_err(|e| e.to_string())? {
+                let entry = entry.map_err(|e| e.to_string())?;
+                let path = entry.path();
+                if !path.is_dir() {
+                    continue;
+                }
+                let name = entry.file_name();
+                let name_str = name.to_string_lossy().to_string();
+                if let Some(filter) = name_filter {
+                    // Simple glob: support * prefix/suffix
+                    if !matches_name(&name_str, filter) {
+                        continue;
+                    }
+                }
+                results.push(path.to_string_lossy().into_owned());
+            }
+            results.sort();
+            Ok(results)
+        }
+        BatchTarget::Glob { pattern } => {
+            // Expand ~ to home dir
+            let expanded = expand_tilde(pattern);
+            let mut results = Vec::new();
+            let entries: Vec<_> = glob::glob(&expanded)
+                .map_err(|e| e.to_string())?
+                .filter_map(|e| e.ok())
+                .filter(|p| p.is_dir())
+                .collect();
+            for entry in entries {
+                results.push(entry.to_string_lossy().into_owned());
+            }
+            results.sort();
+            Ok(results)
+        }
+        BatchTarget::Explicit { paths } => {
+            Ok(paths.clone())
+        }
+    }
+}
+
+/// Glob matching for subdirectory names supporting * and ? wildcards.
+/// Converts the glob pattern to a regex for proper matching.
+fn matches_name(name: &str, pattern: &str) -> bool {
+    let regex_src = pattern
+        .replace('+', r"\+")
+        .replace('.', r"\.")
+        .replace('^', r"\^")
+        .replace('$', r"\$")
+        .replace('{', r"\{")
+        .replace('}', r"\}")
+        .replace('(', r"\(")
+        .replace(')', r"\)")
+        .replace('|', r"\|")
+        .replace('\\', r"\\")
+        .replace('*', ".*")
+        .replace('?', ".");
+    match regex::Regex::new(&format!("(?i)^{}$", regex_src)) {
+        Ok(re) => re.is_match(name),
+        Err(_) => false,
+    }
+}
+
+/// Expand ~ to home directory.
+fn expand_tilde(path: &str) -> String {
+    if path.starts_with("~") {
+        if let Some(home) = std::env::var_os("HOME") {
+            return format!("{}{}", home.to_string_lossy(), &path[1..]);
+        }
+    }
+    path.to_string()
+}
+
+/// Run a single command in the given target directory.
+async fn run_one(
+    command: &str,
+    target: &str,
+    timeout_secs: u64,
+) -> Result<TargetResult, String> {
+    let start = std::time::Instant::now();
+
+    // Pass TARGET as env var to avoid shell injection via path interpolation.
+    let mut cmd = tokio::process::Command::new("bash");
+    let child = match cmd
+        .arg("-c")
+        .arg(command)
+        .env("TARGET", target)
+        .current_dir(target)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            return Ok(TargetResult {
+                path: target.to_string(),
+                status: BatchStatus::Failed { exit_code: -1 },
+                stdout: None,
+                stderr: Some(format!("spawn failed: {}", e)),
+                duration_ms: Some(start.elapsed().as_millis() as u64),
+            });
+        }
+    };
+
+    // Use timeout; if it fires, kill the child to avoid orphaned processes.
+    let result =
+        tokio::time::timeout(
+            std::time::Duration::from_secs(timeout_secs),
+            child.wait_with_output(),
+        )
+        .await;
+
+    if result.is_err() {
+        // Timeout — `wait_with_output` future was dropped. Since
+        // `kill_on_drop(true)` is set on the command, the child is
+        // automatically killed and won't become orphaned.
+    }
+
+    let duration = start.elapsed().as_millis() as u64;
+
+    match result {
+        Ok(Ok(output)) => {
+            let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+            let status = if output.status.success() {
+                BatchStatus::Success
+            } else {
+                BatchStatus::Failed {
+                    exit_code: output
+                        .status
+                        .code()
+                        .unwrap_or(-1),
+                }
+            };
+
+            Ok(TargetResult {
+                path: target.to_string(),
+                status,
+                stdout: if stdout.is_empty() { None } else { Some(stdout) },
+                stderr: if stderr.is_empty() { None } else { Some(stderr) },
+                duration_ms: Some(duration),
+            })
+        }
+        Ok(Err(e)) => Ok(TargetResult {
+            path: target.to_string(),
+            status: BatchStatus::Failed { exit_code: -1 },
+            stdout: None,
+            stderr: Some(e.to_string()),
+            duration_ms: Some(duration),
+        }),
+        Err(_) => Ok(TargetResult {
+            path: target.to_string(),
+            status: BatchStatus::TimedOut,
+            stdout: None,
+            stderr: None,
+            duration_ms: Some(duration),
+        }),
+    }
+}
+
+/// Execute a batch operation across all resolved targets.
+/// If `workspace_root` is provided, targets outside the workspace are filtered out
+/// after resolving symlinks via canonicalize, preventing symlink-based escape.
+pub async fn execute_batch(
+    params: &BatchParams,
+    workspace_root: Option<&str>,
+) -> Result<BatchResponse, ToolError> {
+    // Resolve targets
+    let targets = resolve_targets(&params.targets)
+        .map_err(|e| ToolError::new(ToolErrorCode::InvalidParam, e))?;
+
+    // Canonicalize targets and fence inside workspace if workspace_root is set.
+    let targets: Vec<String> = targets
+        .into_iter()
+        .map(|t| {
+            std::fs::canonicalize(&t)
+                .map(|p| p.to_string_lossy().to_string())
+                .unwrap_or_else(|_| t)
+        })
+        .filter(|t| {
+            // If no workspace_root, allow all targets.
+            if let Some(root) = workspace_root {
+                // Check containment: path must start with root or equal root.
+                // On Unix this is sufficient; on Windows different drives would
+                // fail the starts_with check naturally.
+                t == root || t.starts_with(&format!("{}/", root))
+            } else {
+                true
+            }
+        })
+        .collect();
+
+    if targets.is_empty() {
+        return Ok(BatchResponse::Summary(SummaryResult {
+            total: 0,
+            success: 0,
+            failed: 0,
+            timed_out: 0,
+            message: "No matching targets found.".to_string(),
+        }));
+    }
+
+    // Execute based on mode
+    let results: Vec<TargetResult> = match &params.mode {
+        BatchMode::Sequential => {
+            let mut results = Vec::new();
+            for target in &targets {
+                let result = run_one(&params.command, target, params.timeout_secs)
+                    .await
+                    .map_err(|e| ToolError::new(ToolErrorCode::IoError, e))?;
+                // Note: run_one now returns a Failed TargetResult for spawn errors,
+                // so this branch is only hit for truly unexpected errors.
+
+                if params.fail_fast {
+                    if !matches!(&result.status, BatchStatus::Success | BatchStatus::Skipped) {
+                        // Failed — stop early
+                        results.push(result);
+                        break;
+                    }
+                }
+                results.push(result);
+            }
+            results
+        }
+        BatchMode::Parallel => {
+            let targets_owned: Vec<String> = targets.clone();
+            // Clamp to at least 1 to avoid a zero-permit semaphore that would deadlock.
+            let max_concurrent = params.max_concurrent.max(1);
+            let sem = std::sync::Arc::new(tokio::sync::Semaphore::new(max_concurrent));
+            let mut handles: Vec<tokio::task::JoinHandle<Result<TargetResult, ToolError>>> = Vec::new();
+            let failed = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+
+            for target in targets_owned {
+                let cmd = params.command.clone();
+                let timeout = params.timeout_secs;
+                let sem = sem.clone();
+                let fail_fast = params.fail_fast;
+                let failed = failed.clone();
+
+                handles.push(tokio::spawn(async move {
+                    // Acquire semaphore slot to limit concurrency.
+                    let _permit = match (*sem).acquire().await {
+                        Ok(p) => p,
+                        Err(e) => {
+                            return Ok(TargetResult {
+                                path: target.clone(),
+                                status: BatchStatus::Failed { exit_code: -1 },
+                                stdout: None,
+                                stderr: Some(format!("semaphore error: {}", e)),
+                                duration_ms: None,
+                            });
+                        }
+                    };
+
+                    // Check if we should stop (fail_fast).
+                    if fail_fast && failed.load(std::sync::atomic::Ordering::Relaxed) {
+                        return Ok(TargetResult {
+                            path: target.clone(),
+                            status: BatchStatus::Skipped,
+                            stdout: None,
+                            stderr: None,
+                            duration_ms: Some(0),
+                        });
+                    }
+
+                    // run_one returns a Failed TargetResult for spawn errors,
+                    // so this ? only propagates truly unexpected errors.
+                    let result = run_one(&cmd, &target, timeout).await
+                        .unwrap_or_else(|e| TargetResult {
+                            path: target.clone(),
+                            status: BatchStatus::Failed { exit_code: -1 },
+                            stdout: None,
+                            stderr: Some(format!("unexpected error: {}", e)),
+                            duration_ms: None,
+                        });
+
+                    if fail_fast && !matches!(&result.status, BatchStatus::Success | BatchStatus::Skipped) {
+                        failed.store(true, std::sync::atomic::Ordering::Relaxed);
+                    }
+
+                    Ok(result)
+                }));
+            }
+
+            let mut results = Vec::new();
+            for handle in handles {
+                match handle.await {
+                    Ok(Ok(result)) => {
+                        results.push(result);
+                    }
+                    Ok(Err(_)) => {
+                        // Should not happen (run_one returns TargetResult for errors),
+                        // but handle gracefully.
+                    }
+                    Err(_) => {
+                        // Task join error — skip.
+                    }
+                }
+            }
+            results
+        }
+    };
+
+    // Build response
+    if params.summary_only {
+        build_summary(&results)
+    } else {
+        build_detailed(&results)
+    }
+}
+
+fn build_summary(results: &[TargetResult]) -> Result<BatchResponse, ToolError> {
+    let total = results.len();
+    let success = results
+        .iter()
+        .filter(|r| matches!(&r.status, BatchStatus::Success))
+        .count();
+    let failed = results
+        .iter()
+        .filter(|r| matches!(&r.status, BatchStatus::Failed { .. }))
+        .count();
+    let timed_out = results
+        .iter()
+        .filter(|r| matches!(&r.status, BatchStatus::TimedOut))
+        .count();
+
+    let msg = format!(
+        "Batch complete: {}/{} succeeded, {} failed, {} timed out",
+        success, total, failed, timed_out
+    );
+
+    Ok(BatchResponse::Summary(SummaryResult {
+        total,
+        success,
+        failed,
+        timed_out,
+        message: msg,
+    }))
+}
+
+fn build_detailed(results: &[TargetResult]) -> Result<BatchResponse, ToolError> {
+    let mut lines = Vec::new();
+    lines.push(format!("Batch complete: {} targets", results.len()));
+    lines.push(String::new());
+
+    for r in results {
+        let status_str = match &r.status {
+            BatchStatus::Success => "✓".to_string(),
+            BatchStatus::Failed { exit_code } => format!("✗ (exit {})", exit_code),
+            BatchStatus::TimedOut => "⏱ timeout".to_string(),
+            BatchStatus::Skipped => "○ skipped".to_string(),
+        };
+        lines.push(format!("{} {}", status_str, r.path));
+
+        if let Some(ref stderr) = r.stderr {
+            // Only include stderr for failed jobs to keep output manageable.
+            if !matches!(&r.status, BatchStatus::Success) {
+                lines.push(indent(&stderr.lines().take(5).collect::<Vec<_>>().join("\n")));
+            }
+        }
+    }
+
+    let msg = lines.join("\n");
+
+    // Build per-target metadata
+    let target_results: Vec<serde_json::Value> = results
+        .iter()
+        .map(|r| {
+            let status_str = match &r.status {
+                BatchStatus::Success => "success".to_string(),
+                BatchStatus::Failed { exit_code } => format!("failed({})", exit_code),
+                BatchStatus::TimedOut => "timed_out".to_string(),
+                BatchStatus::Skipped => "skipped".to_string(),
+            };
+            serde_json::json!({
+                "path": r.path,
+                "status": status_str,
+                "duration_ms": r.duration_ms,
+            })
+        })
+        .collect();
+
+    Ok(BatchResponse::Detailed(DetailedResult {
+        message: msg,
+        targets: target_results,
+    }))
+}
+
+fn indent(s: &str) -> String {
+    s.lines()
+        .map(|l| format!("    {}", l))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Batch operation response.
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum BatchResponse {
+    #[serde(rename = "summary")]
+    Summary(SummaryResult),
+    #[serde(rename = "detailed")]
+    Detailed(DetailedResult),
+}
+
+/// Summary result for batch operations.
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
+pub struct SummaryResult {
+    pub total: usize,
+    pub success: usize,
+    pub failed: usize,
+    pub timed_out: usize,
+    pub message: String,
+}
+
+/// Detailed result for batch operations.
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
+pub struct DetailedResult {
+    pub message: String,
+    pub targets: Vec<serde_json::Value>,
+}

--- a/crates/batch/src/schema.rs
+++ b/crates/batch/src/schema.rs
@@ -1,0 +1,87 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Targets for batch operations. Uses `kind`-based tagging to match
+/// the Node schema shape: `{ kind: "subdirs", path: "..." }`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+pub enum BatchTarget {
+    /// Run the command in each immediate subdirectory of the given path.
+    Subdirs {
+        /// Root directory to scan for subdirectories.
+        path: String,
+        /// Optional glob filter for subdirectory names (e.g., "*.git").
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        name_filter: Option<String>,
+    },
+    /// Run the command in each path matching the glob.
+    Glob {
+        /// Glob pattern (e.g., "~/projects/**/*.git").
+        pattern: String,
+    },
+    /// Run the command in each explicitly listed path.
+    Explicit {
+        paths: Vec<String>,
+    },
+}
+
+/// How to execute the batch command.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub enum BatchMode {
+    /// Run sequentially, accumulating results.
+    #[default]
+    Sequential,
+    /// Run in parallel (max_concurrent controls concurrency).
+    Parallel,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BatchParams {
+    /// Shell command to run in each target directory. Use `$TARGET` to
+    /// reference the current directory path.
+    pub command: String,
+    /// What directories/paths to operate on.
+    pub targets: BatchTarget,
+    /// Execution mode.
+    #[serde(default)]
+    pub mode: BatchMode,
+    /// Maximum concurrent commands for parallel mode (default 4).
+    #[serde(default = "default_max_concurrent", alias = "max_concurrent")]
+    pub max_concurrent: usize,
+    /// Timeout per command in seconds (default 120).
+    #[serde(default = "default_timeout_secs", alias = "timeout_secs")]
+    pub timeout_secs: u64,
+    /// If true, stop on first failure.
+    #[serde(default, alias = "fail_fast")]
+    pub fail_fast: bool,
+    /// If true, return only a summary (not full per-target output).
+    #[serde(default, alias = "summary_only")]
+    pub summary_only: bool,
+}
+
+fn default_max_concurrent() -> usize {
+    4
+}
+
+fn default_timeout_secs() -> u64 {
+    120
+}
+
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum BatchParseError {
+    #[error("{0}")]
+    Message(String),
+}
+
+pub fn safe_parse_batch_params(input: &Value) -> Result<BatchParams, BatchParseError> {
+    let parsed: BatchParams = serde_json::from_value(input.clone())
+        .map_err(|e| BatchParseError::Message(e.to_string()))?;
+    if parsed.command.is_empty() {
+        return Err(BatchParseError::Message(
+            "command must not be empty".to_string(),
+        ));
+    }
+    Ok(parsed)
+}

--- a/crates/harness-tools/Cargo.toml
+++ b/crates/harness-tools/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/lib.rs"
 
 [dependencies]
 harness-core = { path = "../harness-core", version = "0.1.0" }
+harness-batch = { path = "../batch", version = "0.1.0" }
 harness-read = { path = "../read", version = "0.1.1" }
 harness-write = { path = "../write", version = "0.1.1" }
 harness-grep = { path = "../grep", version = "0.1.1" }

--- a/crates/harness-tools/src/lib.rs
+++ b/crates/harness-tools/src/lib.rs
@@ -5,13 +5,14 @@
 //! and explicit:
 //!
 //! ```no_run
-//! use harness_tools::{read, bash, grep};
+//! use harness_tools::{read, bash, batch, grep};
 //! # fn main() {}
 //! ```
 //!
 //! If you only need one tool, depend on its individual crate directly
 //! (e.g. `harness-read`) to cut compile time.
 
+pub use harness_batch as batch;
 pub use harness_bash as bash;
 pub use harness_core as core;
 pub use harness_glob as glob;

--- a/crates/write/src/engine.rs
+++ b/crates/write/src/engine.rs
@@ -26,11 +26,20 @@ pub enum PipelineResult {
     },
 }
 
+/// Strip leading and trailing whitespace from each line, preserving line
+/// count and internal spacing. Uses split('\n') to keep the trailing empty
+/// line when the string ends with \n, so "foo\n" stays as two lines rather
+/// than collapsing to one (which would match "foo_extra" incorrectly).
+fn strip_line_whitespace(s: &str) -> String {
+    s.split('\n').map(|l| l.trim()).collect::<Vec<_>>().join("\n")
+}
+
 /// Apply a single edit spec to `content`. Returns either the new content +
 /// counts, or a structured ToolError.
 pub fn apply_edit(content: &str, edit: &EditSpec) -> Result<ApplyResult, ToolError> {
     let old_raw = &edit.old_string;
     let new_raw = &edit.new_string;
+    let ignore_ws = edit.ignore_whitespace.unwrap_or(false);
 
     if old_raw == new_raw {
         return Err(ToolError::new(
@@ -50,7 +59,15 @@ pub fn apply_edit(content: &str, edit: &EditSpec) -> Result<ApplyResult, ToolErr
         ));
     }
 
-    let offsets = find_all_occurrences(&norm_content, &norm_old);
+    // When ignore_whitespace is true, match against whitespace-stripped
+    // versions but replace in the original text.
+    let (search_content, search_needle) = if ignore_ws {
+        (strip_line_whitespace(&norm_content), strip_line_whitespace(&norm_old))
+    } else {
+        (norm_content.clone(), norm_old.clone())
+    };
+
+    let offsets = find_all_occurrences(&search_content, &search_needle);
 
     if offsets.is_empty() {
         let candidates = find_fuzzy_candidates(&norm_content, &norm_old, FuzzyOpts::default());
@@ -72,7 +89,7 @@ pub fn apply_edit(content: &str, edit: &EditSpec) -> Result<ApplyResult, ToolErr
 
     let replace_all = edit.replace_all.unwrap_or(false);
     if offsets.len() > 1 && !replace_all {
-        let locations = build_match_locations(&norm_content, &norm_old, &offsets);
+        let locations = build_match_locations(&search_content, &search_needle, &offsets);
         let block = format_match_locations(&locations);
         let msg = format!(
             "old_string matches {} locations; edit requires exactly one match.\n\n{}\n\nWiden old_string with surrounding context so it matches exactly one location, or pass replace_all: true if you intend to replace every occurrence.",
@@ -94,8 +111,8 @@ pub fn apply_edit(content: &str, edit: &EditSpec) -> Result<ApplyResult, ToolErr
     };
 
     let mut warnings: Vec<String> = Vec::new();
-    if replace_all && offsets.len() > 1 {
-        let flagged = substring_boundary_collisions(&norm_content, &norm_old, &offsets);
+    if replace_all && offsets.len() > 1 && !ignore_ws {
+        let flagged = substring_boundary_collisions(&norm_content, &norm_old, &target_offsets);
         if !flagged.is_empty() {
             let lines_str = flagged
                 .iter()
@@ -110,7 +127,14 @@ pub fn apply_edit(content: &str, edit: &EditSpec) -> Result<ApplyResult, ToolErr
         }
     }
 
-    let new_content = replace_at_offsets(&norm_content, &norm_old, &norm_new, &target_offsets);
+    // When ignore_whitespace is true, the offsets are from the stripped
+    // content. Map them back to line ranges in the original content and
+    // replace those lines.
+    let new_content = if ignore_ws {
+        replace_by_line_range(&norm_content, &search_content, &search_needle, &norm_new, &target_offsets)
+    } else {
+        replace_at_offsets(&norm_content, &norm_old, &norm_new, &target_offsets)
+    };
 
     Ok(ApplyResult {
         content: new_content,
@@ -172,6 +196,158 @@ fn replace_at_offsets(
     }
     out.push_str(&haystack[cursor..]);
     out
+}
+
+/// Replace text by mapping byte offsets from a whitespace-stripped version
+/// back to the original content. For single-line matches, replaces the
+/// matched substring within the line (preserving surrounding text). For
+/// multi-line matches, replaces the entire line range.
+fn replace_by_line_range(
+    original: &str,
+    stripped: &str,
+    old_stripped: &str,
+    replacement: &str,
+    stripped_offsets: &[usize],
+) -> String {
+    let orig_lines: Vec<&str> = original.split('\n').collect();
+    let strip_lines: Vec<&str> = stripped.split('\n').collect();
+
+    // Number of lines the old_string spans.
+    let old_line_count = old_stripped.split('\n').count();
+    let replace_lines: Vec<&str> = replacement.split('\n').collect();
+
+    // Check if this is a single-line match — if so, do substring replacement
+    // to preserve surrounding text on the line.
+    let single_line = old_line_count == 1 && replace_lines.len() == 1;
+
+    // Build (line_idx, byte_offset_in_stripped_line) for each match.
+    let mut positions: Vec<(usize, usize)> = Vec::new();
+    for &off in stripped_offsets {
+        let mut line_idx = 0usize;
+        let mut byte_pos = 0usize;
+        let mut found = false;
+        for (i, line) in strip_lines.iter().enumerate() {
+            if byte_pos <= off && off < byte_pos + line.len() {
+                line_idx = i;
+                found = true;
+                break;
+            }
+            byte_pos += line.len() + 1; // +1 for the '\n'
+        }
+        // If offset lands on a newline boundary (empty stripped line),
+        // advance to the next line so we don't silently fall back to line 0.
+        if !found && byte_pos <= off && off < byte_pos + strip_lines.get(line_idx).map(|l| l.len()).unwrap_or(0) {
+            found = true;
+        }
+        if !found {
+            // Offset past all lines — clamp to last line to avoid underflow.
+            line_idx = (line_idx).min(strip_lines.len().saturating_sub(1));
+            byte_pos = if line_idx == 0 { 0 } else {
+                strip_lines[..line_idx].iter().map(|l| l.len() + 1).sum()
+            };
+        }
+        let byte_pos = byte_pos.min(off);
+        let offset_in_line = off - byte_pos;
+        positions.push((line_idx, offset_in_line));
+    }
+
+    let mut result_lines: Vec<String> = orig_lines.iter().map(|l| l.to_string()).collect();
+
+    if single_line {
+        // Single-line: replace the matched span within each original line,
+        // preserving surrounding text. Map the byte offset from the stripped
+        // line back to the original line to find the correct position.
+        for (line_idx, stripped_off) in positions.iter().rev() {
+            if let Some(line) = result_lines.get_mut(*line_idx) {
+                let orig_line = line.as_str();
+                // Find leading whitespace length in the original line.
+                let lead_ws = orig_line.len() - orig_line.trim_start().len();
+
+                // The match starts at `stripped_off` bytes into the stripped
+                // line (which is the original line with leading/trailing
+                // whitespace removed). Map to the original line:
+                let orig_start = lead_ws + stripped_off;
+                let orig_end = orig_start + old_stripped.len();
+
+                if orig_start <= orig_line.len() && orig_end <= orig_line.len() {
+                    let new_line = format!(
+                        "{}{}{}",
+                        &orig_line[..orig_start],
+                        replacement,
+                        &orig_line[orig_end..]
+                    );
+                    *line = new_line;
+                } else {
+                    // Offset mapping failed — fall back to full line replace.
+                    *line = replacement.to_string();
+                }
+            }
+        }
+    } else {
+        // Multi-line: replace matched range while preserving surrounding text
+        // on the first and last lines. For "prefix old1\nold2 suffix" matching
+        // "old1\nold2", this preserves "prefix " and " suffix".
+        let needle_lines: Vec<&str> = old_stripped.split('\n').collect();
+        let first_trimmed = needle_lines.first().map(|l| l.trim()).unwrap_or("");
+        let last_trimmed = needle_lines.last().map(|l| l.trim()).unwrap_or("");
+        let mut ranges: Vec<(usize, usize)> = Vec::new();
+        for (line_idx, _offset) in &positions {
+            ranges.push((*line_idx, *line_idx + old_line_count));
+        }
+        for (start, end) in ranges.into_iter().rev() {
+            let clamped_start = start.min(result_lines.len());
+            let clamped_end = end.min(result_lines.len());
+
+            // Preserve prefix on the first line.
+            let prefix = if let Some(first_line) = result_lines.get(clamped_start) {
+                let match_pos = first_line.find(first_trimmed);
+                if let Some(pos) = match_pos {
+                    first_line[..pos].to_string()
+                } else {
+                    String::new()
+                }
+            } else {
+                String::new()
+            };
+
+            // Preserve suffix on the last line.
+            let suffix = if let Some(last_line) = result_lines.get(clamped_end - 1) {
+                let match_pos = last_line.find(last_trimmed);
+                if let Some(pos) = match_pos {
+                    let end_pos = pos + last_trimmed.len();
+                    if end_pos <= last_line.len() {
+                        last_line[end_pos..].to_string()
+                    } else {
+                        String::new()
+                    }
+                } else {
+                    String::new()
+                }
+            } else {
+                String::new()
+            };
+
+            let mut new_lines: Vec<String> = replace_lines.iter().map(|l| l.to_string()).collect();
+
+            // Prepend prefix to the first replacement line.
+            if !prefix.is_empty() {
+                if let Some(first) = new_lines.first_mut() {
+                    *first = format!("{}{}", prefix, first);
+                }
+            }
+
+            // Append suffix to the last replacement line.
+            if !suffix.is_empty() {
+                if let Some(last) = new_lines.last_mut() {
+                    *last = format!("{}{}", last, suffix);
+                }
+            }
+
+            result_lines.splice(clamped_start..clamped_end, new_lines);
+        }
+    }
+
+    result_lines.join("\n")
 }
 
 fn truncate_for_warning(s: &str) -> String {

--- a/crates/write/src/run.rs
+++ b/crates/write/src/run.rs
@@ -320,10 +320,11 @@ async fn execute_edit(
         Err(e) => return err_e(e),
     };
 
-    let edit_spec = EditSpec {
+   let edit_spec = EditSpec {
         old_string: params.old_string.clone(),
         new_string: params.new_string.clone(),
         replace_all: params.replace_all,
+        ignore_whitespace: params.ignore_whitespace,
     };
 
     let result = match apply_edit(&pre.existing_content, &edit_spec) {
@@ -440,6 +441,7 @@ async fn execute_multi_edit(
             old_string: e.old_string.clone(),
             new_string: e.new_string.clone(),
             replace_all: e.replace_all,
+            ignore_whitespace: e.ignore_whitespace,
         })
         .collect();
 

--- a/crates/write/src/schema.rs
+++ b/crates/write/src/schema.rs
@@ -18,6 +18,10 @@ pub struct EditParams {
     pub replace_all: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub dry_run: Option<bool>,
+    /// When true, leading/trailing whitespace on each line is ignored
+    /// during matching. The replacement uses the exact new_string text.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ignore_whitespace: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -27,6 +31,10 @@ pub struct EditSpec {
     pub new_string: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub replace_all: Option<bool>,
+    /// When true, leading/trailing whitespace on each line is ignored
+    /// during matching.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ignore_whitespace: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/docs/session-feedback-2026-06-05.md
+++ b/docs/session-feedback-2026-06-05.md
@@ -1,0 +1,91 @@
+# Session Feedback — 2026-06-05
+
+## Context
+Large-scale cleanup session: synced 42 Git repos, resolved merge conflicts, rebuilt all Rust projects with optimized release profiles + mimalloc, cleaned 150+ GB of stale artifacts.
+
+---
+
+## Issues Encountered
+
+### 1. Background job polling is broken
+
+`bash_output(job_id)` returned `NOT_FOUND` for every cargo build. I had to poll repeatedly with errors, making it impossible to track progress on long-running builds. This was the most frustrating limitation — I essentially ran blind on 10+ background jobs.
+
+**Root cause**: `executor.rs:317-324` — jobs stored in an in-process `HashMap` inside `LocalBashExecutor`. If the executor is recreated between tool calls (new session, process restart, or executor swap), all job IDs are lost. No persistent job store.
+
+**Desired fix**: Disk-backed job registry so background jobs survive executor recreation. At minimum, completed jobs should remain queryable until explicitly cleaned up.
+
+### 2. edit tool is fragile with whitespace
+
+When resolving merge conflicts, the conflict markers had subtle whitespace differences that made exact string matching fail repeatedly. I had to fall back to `sed` for most of it.
+
+**Root cause**: `matching.rs:56-86` — byte-level exact matching after LF normalization. No tolerance for trailing whitespace, tab/space differences, or indentation shifts.
+
+**Desired fix**:
+- `ignore_whitespace: true` option on edit specs
+- Fuzzy-match mode that tolerates whitespace-only diffs
+- Line-range edits (`startLine`/`endLine` replacement) to bypass exact string matching
+
+### 3. No batch operations (FIXED)
+
+Having to loop through 42+ repos for fetch, prune, push, branch cleanup, etc. was verbose.
+
+**Fix**: Implemented `@agent-sh/harness-batch` — a generic batch tool that runs commands across multiple directories. Supports:
+- `subdirs` target mode (run in each subdirectory of a path)
+- `glob` target mode (run in each path matching a glob)
+- `explicit` target mode (run in each explicitly listed path)
+- Sequential and parallel execution modes
+- Fail-fast, timeout control, summary-only output
+- Both Rust (`harness-batch`) and Node.js (`@agent-sh/harness-batch`) implementations
+
+### 4. No file system state tracking
+
+I had to manually verify every change (did the build succeed? did the conflict resolve?). A tool that could diff working tree state before/after operations, or track "did this build produce new binaries?" would reduce verification noise.
+
+**Desired fix**:
+- Post-operation status summary (e.g., after bash: "3 files changed, 2 new binaries produced")
+- Ability to track file state snapshots and diff between them
+- Build artifact detection ("new release binary is 12% smaller than previous")
+
+### 5. grep -r across repos is slow
+
+Finding all `Cargo.toml` files, all `main.rs` files, etc. across nested workspace structures required multiple `find` commands. A workspace-aware tool that understood Rust/Cargo structure would be useful.
+
+**Desired fix**:
+- `--workspace` flag that detects Cargo workspaces and only searches source directories (not `target/`, `node_modules/`, etc.)
+- Language-aware file discovery (`find-binary-crate`, `find-library-crate`)
+
+---
+
+## What Worked Well
+
+- **bash** for bulk operations (cleaning, loops, git) — reliable and fast
+- **read/grep** for inspecting files — accurate and well-behaved
+- **github tool** for the initial conflict resolution in `codex-desktop-linux` — handled the complex 3-way merge cleanly
+
+---
+
+## Priority Ranking
+
+| Priority | Issue | Status | Impact |
+|----------|-------|--------|--------|
+| **P0** | Background job polling | ✅ Fixed | Directly breaks long-running workflows |
+| **P1** | Edit whitespace fragility | ✅ Fixed | Forces workarounds, wastes rounds |
+| **P2** | No batch operations | ✅ Fixed | Verbose but functional with bash loops |
+| **P3** | No state tracking | Open | Quality-of-life, reduces verification |
+| **P3** | Workspace-aware grep | Open | Quality-of-life for monorepos |
+
+---
+
+## Forward-Looking Wishlist
+
+1. ~~**Persistent background job store** with TTL and explicit cleanup~~ ✅ Implemented
+2. **Edit by line range** as first-class operation (not just string replacement)
+3. ~~**Batch/multirepo actions** for git, file ops, and builds~~ ✅ Implemented
+4. **Post-operation summaries** that auto-detect meaningful changes
+5. **Workspace-aware discovery** for Cargo, npm, Go modules, etc.
+6. **Streaming output for background jobs** instead of file-based polling
+7. **Idempotent edit mode** — "ensure this block exists" rather than "replace exact string"
+8. **Structured error recovery** — suggest fixes instead of just erroring (e.g., "whitespace mismatch at column 4, retry with tabs→spaces?")
+9. **Batch operation hooks** — pre/post callbacks for batch operations
+10. **Batch retry with exponential backoff** for transient failures

--- a/packages/bash/src/executor.ts
+++ b/packages/bash/src/executor.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { mkdirSync, createWriteStream, existsSync, readFileSync, statSync } from "node:fs";
+import { mkdirSync, createWriteStream, existsSync, readFileSync, statSync, readdirSync, writeFileSync, unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
@@ -10,6 +10,89 @@ import type {
   BashRunInput,
   BashRunResult,
 } from "./types.js";
+
+/** Job metadata persisted to disk for cross-session restoration. */
+interface JobMeta {
+  outPath: string;
+  errPath: string;
+  running: boolean;
+  exitCode: number | null;
+  createdAt: number; // epoch seconds
+  childPid: number | undefined; // PID for liveness check on restore
+}
+
+/** In-memory job state. */
+interface Job {
+  id: string;
+  outPath: string;
+  errPath: string;
+  running: boolean;
+  exitCode: number | null;
+  killed: boolean;
+  proc: ReturnType<typeof spawn> | null;
+}
+
+/** Write job metadata to disk. Idempotent — safe to call multiple times. */
+function persistJobMeta(logDir: string, jobId: string, meta: JobMeta): void {
+  const metaDir = path.join(logDir, "job-meta");
+  try {
+    mkdirSync(metaDir, { recursive: true });
+  } catch {
+    // real error (e.g. permission denied); mkdirSync({recursive:true})
+    // does NOT throw on EEXIST, so this only fires on genuine failures
+    return;
+  }
+  try {
+    writeFileSync(
+      path.join(metaDir, `${jobId}.json`),
+      JSON.stringify(meta),
+    );
+  } catch {
+    // ignore — non-fatal
+  }
+}
+
+/** Load completed jobs from disk and restore them into the jobs map. */
+function loadJobsFromDisk(
+  logDir: string,
+  jobs: Map<string, Job>,
+): void {
+  const metaDir = path.join(logDir, "job-meta");
+  if (!existsSync(metaDir)) return;
+  const now = Date.now() / 1000;
+  const TTL_SECS = 7 * 24 * 60 * 60; // 7 days
+  try {
+    for (const fname of readdirSync(metaDir)) {
+      if (!fname.endsWith(".json")) continue;
+      const metaPath = path.join(metaDir, fname);
+      try {
+        const data = JSON.parse(readFileSync(metaPath, "utf8")) as JobMeta;
+        // Prune expired jobs
+        if (now - data.createdAt > TTL_SECS) {
+          try { unlinkSync(metaPath); } catch {}
+          continue;
+        }
+        const jobId = fname.slice(0, -5); // strip .json
+        // Only restore jobs not already in memory
+        if (!jobs.has(jobId) && !data.running) {
+          jobs.set(jobId, {
+            id: jobId,
+            outPath: data.outPath,
+            errPath: data.errPath,
+            running: false,
+            exitCode: data.exitCode,
+            killed: false,
+            proc: null,
+          });
+        }
+      } catch {
+        // skip corrupt entries
+      }
+    }
+  } catch {
+    // meta dir doesn't exist or unreadable
+  }
+}
 
 /**
  * Default local-subprocess executor.
@@ -32,17 +115,10 @@ export function createLocalBashExecutor(opts?: {
   const logDir = opts?.logDir ?? path.join(tmpdir(), "agent-sh-bash-logs");
   mkdirSync(logDir, { recursive: true });
 
-  interface Job {
-    readonly id: string;
-    readonly outPath: string;
-    readonly errPath: string;
-    running: boolean;
-    exitCode: number | null;
-    killed: boolean;
-    proc: ReturnType<typeof spawn> | null;
-  }
-
   const jobs = new Map<string, Job>();
+
+  // Restore completed jobs from disk (persisted across executor restarts).
+  loadJobsFromDisk(logDir, jobs);
 
   async function runForeground(input: BashRunInput): Promise<BashRunResult> {
     const child = spawn(bashPath, ["-c", input.command], {
@@ -120,14 +196,42 @@ export function createLocalBashExecutor(opts?: {
     };
     jobs.set(jobId, job);
 
+    // Persist metadata immediately so in-flight jobs survive executor restart.
+    persistJobMeta(logDir, jobId, {
+      outPath,
+      errPath,
+      running: true,
+      exitCode: null,
+      createdAt: Math.floor(Date.now() / 1000),
+      childPid: child.pid,
+    });
+
     child.on("close", (code) => {
       job.running = false;
       job.exitCode = code;
       job.proc = null;
+      // Persist final state for cross-session queries.
+      persistJobMeta(logDir, jobId, {
+        outPath,
+        errPath,
+        running: false,
+        exitCode: code,
+        createdAt: Math.floor(Date.now() / 1000),
+        childPid: undefined,
+      });
     });
     child.on("error", () => {
       job.running = false;
       job.proc = null;
+      // Persist error state.
+      persistJobMeta(logDir, jobId, {
+        outPath,
+        errPath,
+        running: false,
+        exitCode: null,
+        createdAt: Math.floor(Date.now() / 1000),
+        childPid: undefined,
+      });
     });
 
     return { jobId };
@@ -137,9 +241,63 @@ export function createLocalBashExecutor(opts?: {
     jobId: string,
     opts: { since_byte?: number; head_limit?: number },
   ): Promise<BackgroundReadResult> {
-    const job = jobs.get(jobId);
+    let job = jobs.get(jobId);
+
+    // If the job isn't in memory, try to restore it from disk.
     if (!job) {
-      throw new Error(`Unknown job_id: ${jobId}`);
+      // Reject path separators in job IDs to prevent directory traversal.
+      if (jobId.includes("/") || jobId.includes("\\") || jobId.includes("\0")) {
+        throw new Error(`Invalid job_id: ${jobId}`);
+      }
+      const metaPath = path.join(logDir, "job-meta", `${jobId}.json`);
+      try {
+        const data = JSON.parse(readFileSync(metaPath, "utf8")) as JobMeta;
+        job = {
+          id: jobId,
+          outPath: data.outPath,
+          errPath: data.errPath,
+          running: data.running,
+          exitCode: data.exitCode,
+          killed: false,
+          proc: null,
+        };
+        jobs.set(jobId, job);
+      } catch {
+        throw new Error(`Unknown job_id: ${jobId}`);
+      }
+    }
+
+    // For restored jobs with no child handle, re-read metadata from disk
+    // and check liveness so we detect completion after the old executor died.
+    if (job.running && !job.proc) {
+      try {
+        const metaPath = path.join(logDir, "job-meta", `${jobId}.json`);
+        const data = JSON.parse(readFileSync(metaPath, "utf8")) as JobMeta;
+        if (!data.running) {
+          // Metadata was updated by the waiter — job is done.
+          job.running = false;
+          job.exitCode = data.exitCode;
+        } else if (data.childPid != null) {
+          // Metadata still says running — check if the PID is actually alive.
+          // process.kill(pid, 0) throws if the process doesn't exist.
+          let stillAlive = true;
+          try {
+            process.kill(data.childPid, 0);
+          } catch {
+            stillAlive = false;
+          }
+          if (!stillAlive) {
+            // Child is gone but metadata was never updated (executor died
+            // before the close handler fired). Mark as done with inferred exit.
+            job.running = false;
+            job.exitCode = 0; // best guess; output files still readable
+          }
+        }
+        // If no childPid and no metadata update, we can't determine liveness;
+        // fall through with cached state. The job may have already exited.
+      } catch {
+        // Metadata may not exist or may be stale; fall through with cached state.
+      }
     }
     const since = opts.since_byte ?? 0;
     const limit = opts.head_limit ?? 30_720;

--- a/packages/batch/package.json
+++ b/packages/batch/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@agent-sh/harness-batch",
+  "version": "0.1.0",
+  "description": "Batch tool for AI agent harnesses — execute commands across multiple directories with glob, subdirs, or explicit targets; sequential or parallel execution; fail-fast; summary or detailed output",
+  "keywords": [
+    "ai",
+    "agent",
+    "llm",
+    "tool-use",
+    "batch",
+    "parallel",
+    "git",
+    "bedrock",
+    "openai"
+  ],
+  "license": "MIT",
+  "author": "Avi Fenesh",
+  "homepage": "https://github.com/avifenesh/tools/tree/main/packages/batch#readme",
+  "bugs": {
+    "url": "https://github.com/avifenesh/tools/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/avifenesh/tools.git",
+    "directory": "packages/batch"
+  },
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist .turbo"
+  },
+  "dependencies": {
+    "@agent-sh/harness-core": "workspace:*",
+    "fast-glob": "^3.3.2",
+    "valibot": "^1.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.9.0",
+    "tsup": "^8.3.5",
+    "typescript": "^5.6.3",
+    "vitest": "^2.1.4"
+  }
+}

--- a/packages/batch/src/batch.ts
+++ b/packages/batch/src/batch.ts
@@ -1,0 +1,369 @@
+import { execFile } from "node:child_process";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import fg from "fast-glob";
+import {
+  type BatchParams,
+  type BatchTarget,
+  type BatchTargetSubdirs,
+  type BatchTargetGlob,
+  type BatchTargetExplicit,
+  type TargetResult,
+  type BatchSummary,
+} from "./types.js";
+
+const DEFAULT_TIMEOUT_SECS = 120;
+const DEFAULT_MAX_CONCURRENT = 4;
+
+/// Resolve targets from the batch params, canonicalizing each result
+/// via realpath to prevent symlink escapes.
+export async function resolveTargets(
+  targets: BatchTarget,
+): Promise<string[]> {
+  let raw: string[];
+  switch (targets.kind) {
+    case "subdirs":
+      raw = await resolveSubdirs(targets);
+      break;
+    case "glob":
+      raw = await resolveGlob(targets);
+      break;
+    case "explicit":
+      raw = await resolveExplicit(targets);
+      break;
+  }
+  // Canonicalize every target to prevent symlink escapes.
+  // Keep broken paths so execution can report them naturally.
+  const resolved: string[] = [];
+  for (const p of raw) {
+    try {
+      resolved.push(await fs.realpath(p));
+    } catch {
+      // realpath failed — keep the resolved path so the executor reports it.
+      resolved.push(p);
+    }
+  }
+  return resolved;
+}
+
+async function resolveSubdirs(t: BatchTargetSubdirs): Promise<string[]> {
+  const expanded = expandTilde(t.path);
+  const stat = await fs.stat(expanded).catch(() => null);
+  if (!stat?.isDirectory()) {
+    throw new Error(`Not a directory: ${expanded}`);
+  }
+
+  const entries = await fs.readdir(expanded, { withFileTypes: true });
+  const results: string[] = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const name = entry.name;
+
+    if (t.name_filter && !matchesName(name, t.name_filter)) {
+      continue;
+    }
+
+    results.push(path.join(expanded, name));
+  }
+
+  results.sort();
+  return results;
+}
+
+async function resolveGlob(t: BatchTargetGlob): Promise<string[]> {
+  const expanded = expandTilde(t.pattern);
+  const matches = await fg(expanded, {
+    onlyDirectories: true,
+    dot: true,
+    absolute: true,
+  });
+  matches.sort();
+  return matches;
+}
+
+function resolveExplicit(t: BatchTargetExplicit): string[] {
+  return t.paths.map((p) => expandTilde(p));
+}
+
+/// Glob matching for subdirectory names supporting * and ? wildcards.
+/// Converts the glob pattern to a regex for proper matching.
+function matchesName(name: string, pattern: string): boolean {
+  // Convert glob pattern to regex: * → .*, ? → ., escape other specials.
+  const regexSrc = pattern
+    .replace(/[.+^${}()|\\]/g, "\\$&")
+    .replace(/\*/g, ".*")
+    .replace(/\?/g, ".");
+  const regex = new RegExp(`^${regexSrc}$`, "i");
+  return regex.test(name);
+}
+
+/// Expand ~ to home directory.
+function expandTilde(p: string): string {
+  if (p.startsWith("~")) {
+    const home = process.env.HOME ?? "";
+    return path.join(home, p.slice(1));
+  }
+  return p;
+}
+
+/// Run a single command in the given target directory.
+async function runOne(
+  command: string,
+  target: string,
+  timeoutMs: number,
+): Promise<TargetResult> {
+  const start = Date.now();
+
+  // Pass TARGET as env var to avoid shell injection via path interpolation.
+  const env = { ...process.env, TARGET: target };
+
+  return new Promise((resolve) => {
+    execFile(
+      "bash",
+      ["-c", command],
+      { cwd: target, timeout: timeoutMs, env, maxBuffer: 50 * 1024 * 1024 },
+      (error, stdout, stderr) => {
+        const duration = Date.now() - start;
+        const stdoutStr = stdout?.trim();
+        const stderrStr = stderr?.trim();
+
+        if (error) {
+          // Check if it was a timeout (spawnerr: ETIMEDOUT)
+          if (error.signal === "SIGTERM" || (error as any).spawnerr === "ETIMEDOUT") {
+            resolve({
+              path: target,
+              status: "timed_out",
+              duration_ms: duration,
+              ...(stderrStr ? { stderr: stderrStr } : {}),
+            });
+          } else {
+            resolve({
+              path: target,
+              status: "failed",
+              exit_code: (error as any).status ?? -1,
+              duration_ms: duration,
+              ...(stdoutStr ? { stdout: stdoutStr } : {}),
+              ...(stderrStr ? { stderr: stderrStr } : {}),
+            });
+          }
+        } else {
+          resolve({
+            path: target,
+            status: "success",
+            duration_ms: duration,
+            ...(stdoutStr ? { stdout: stdoutStr } : {}),
+            ...(stderrStr ? { stderr: stderrStr } : {}),
+          });
+        }
+      },
+    );
+  });
+}
+
+/// Run commands sequentially.
+async function runSequential(
+  command: string,
+  targets: string[],
+  timeoutSecs: number,
+  failFast: boolean,
+): Promise<TargetResult[]> {
+  const results: TargetResult[] = [];
+  const timeoutMs = timeoutSecs * 1000;
+
+  for (const target of targets) {
+    const result = await runOne(command, target, timeoutMs);
+    results.push(result);
+
+    if (failFast && result.status !== "success" && result.status !== "skipped") {
+      break;
+    }
+  }
+
+  return results;
+}
+
+/// Run commands in parallel with concurrency control.
+async function runParallel(
+  command: string,
+  targets: string[],
+  timeoutSecs: number,
+  maxConcurrent: number,
+  failFast: boolean,
+): Promise<TargetResult[]> {
+  const results: TargetResult[] = [];
+  const timeoutMs = timeoutSecs * 1000;
+  let failed = false;
+
+  const queue = [...targets];
+  const running = new Set<Promise<void>>();
+
+  while ((queue.length > 0 || running.size > 0) && !(failFast && failed)) {
+    // Fill up to max_concurrent
+    while (running.size < maxConcurrent && queue.length > 0 && !(failFast && failed)) {
+      const target = queue.shift()!;
+      const promise = (async () => {
+        const result = await runOne(command, target, timeoutMs);
+        results.push(result);
+        if (failFast && result.status !== "success" && result.status !== "skipped") {
+          failed = true;
+        }
+      })();
+      running.add(promise);
+      promise.finally(() => running.delete(promise));
+    }
+
+    if (running.size > 0) {
+      await Promise.race(running);
+    }
+  }
+
+  // Drain in-flight jobs before returning (fail-fast still waits for them).
+  if (running.size > 0) {
+    await Promise.all(running);
+  }
+
+  return results;
+}
+
+/// Build a summary from results.
+function buildSummary(results: TargetResult[]): BatchSummary {
+  const summary: BatchSummary = {
+    total: results.length,
+    success: 0,
+    failed: 0,
+    timed_out: 0,
+  };
+
+  for (const r of results) {
+    switch (r.status) {
+      case "success":
+        summary.success++;
+        break;
+      case "failed":
+        summary.failed++;
+        break;
+      case "timed_out":
+        summary.timed_out++;
+        break;
+    }
+  }
+
+  return summary;
+}
+
+/// Main batch execution entry point.
+/// If `workspaceRoot` is provided, targets outside the workspace are filtered out.
+export async function executeBatch(
+  params: BatchParams,
+  workspaceRoot?: string,
+): Promise<{
+  message: string;
+  meta: Record<string, unknown>;
+}> {
+  const targets = await resolveTargets(params.targets);
+
+  // Filter out targets that escape the workspace (via symlinks etc.).
+  let finalTargets = targets;
+  if (workspaceRoot) {
+    const realRoot = await fs.realpath(workspaceRoot);
+    finalTargets = targets.filter((t) => {
+      const rel = path.relative(realRoot, t);
+      // Allow workspace root itself (rel === "") and any path inside it.
+      return !rel.startsWith("..");
+    });
+  }
+
+  if (finalTargets.length === 0) {
+    return {
+      message: "No matching targets found.",
+      meta: {},
+    };
+  }
+
+  const timeoutSecs = params.timeout_secs ?? DEFAULT_TIMEOUT_SECS;
+  const maxConcurrent = params.max_concurrent ?? DEFAULT_MAX_CONCURRENT;
+  const failFast = params.fail_fast ?? false;
+
+  const results: TargetResult[] =
+    params.mode === "parallel"
+      ? await runParallel(
+          params.command,
+          finalTargets,
+          timeoutSecs,
+          maxConcurrent,
+          failFast,
+        )
+      : await runSequential(params.command, finalTargets, timeoutSecs, failFast);
+
+  if (params.summary_only) {
+    return buildSummaryResponse(results);
+  }
+
+  return buildDetailedResponse(results);
+}
+
+function buildSummaryResponse(results: TargetResult[]): {
+  message: string;
+  meta: Record<string, unknown>;
+} {
+  const summary = buildSummary(results);
+  const failedTargets = results
+    .filter((r) => r.status === "failed")
+    .map((r) => r.path);
+
+  return {
+    message: `Batch complete: ${summary.success}/${summary.total} succeeded, ${summary.failed} failed, ${summary.timed_out} timed out`,
+    meta: {
+      summary,
+      failed_targets: failedTargets,
+    },
+  };
+}
+
+function buildDetailedResponse(results: TargetResult[]): {
+  message: string;
+  meta: Record<string, unknown>;
+} {
+  const lines: string[] = [];
+  lines.push(`Batch complete: ${results.length} targets`);
+  lines.push("");
+
+  for (const r of results) {
+    const statusStr =
+      r.status === "success"
+        ? "✓"
+        : r.status === "failed"
+          ? `✗ (exit ${r.exit_code ?? -1})`
+          : r.status === "timed_out"
+            ? "⏱ timeout"
+            : "○ skipped";
+
+    lines.push(`${statusStr} ${r.path}`);
+
+    // Include stderr for failed jobs (up to 5 lines).
+    if (r.status !== "success" && r.stderr) {
+      const errLines = r.stderr.split("\n").slice(0, 5);
+      for (const line of errLines) {
+        lines.push(`    ${line}`);
+      }
+    }
+  }
+
+  const targetResults = results.map((r) => ({
+    path: r.path,
+    status: r.status,
+    exit_code: r.exit_code,
+    duration_ms: r.duration_ms,
+    stdout: r.stdout
+      ? r.stdout.split("\n").slice(0, 10).join("\n")
+      : undefined,
+  }));
+
+  return {
+    message: lines.join("\n"),
+    meta: {
+      targets: targetResults,
+    },
+  };
+}

--- a/packages/batch/src/index.ts
+++ b/packages/batch/src/index.ts
@@ -1,0 +1,4 @@
+export { executeBatch } from "./batch.js";
+export { safeParseBatchParams } from "./schema.js";
+export { batchToolDefinition, BATCH_TOOL_NAME, BATCH_TOOL_DESCRIPTION } from "./schema.js";
+export type { BatchParams, BatchTarget, TargetResult, BatchSummary } from "./types.js";

--- a/packages/batch/src/schema.ts
+++ b/packages/batch/src/schema.ts
@@ -1,0 +1,226 @@
+import * as v from "valibot";
+import type { ToolDefinition } from "@agent-sh/harness-core";
+import type {
+  BatchParams,
+  BatchTargetSubdirs,
+  BatchTargetGlob,
+  BatchTargetExplicit,
+} from "./types.js";
+
+// Target schemas
+
+export const BatchTargetSubdirsSchema = v.strictObject({
+  kind: v.literal("subdirs"),
+  path: v.pipe(v.string(), v.minLength(1, "path is required")),
+  name_filter: v.optional(v.string()),
+});
+
+export const BatchTargetGlobSchema = v.strictObject({
+  kind: v.literal("glob"),
+  pattern: v.pipe(v.string(), v.minLength(1, "pattern is required")),
+});
+
+export const BatchTargetExplicitSchema = v.strictObject({
+  kind: v.literal("explicit"),
+  paths: v.pipe(
+    v.array(v.pipe(v.string(), v.minLength(1, "path must not be empty"))),
+    v.minLength(1, "paths must contain at least one entry"),
+  ),
+});
+
+export const BatchTargetSchema = v.union([
+  BatchTargetSubdirsSchema,
+  BatchTargetGlobSchema,
+  BatchTargetExplicitSchema,
+]);
+
+export type ParsedBatchTarget =
+  | v.InferOutput<typeof BatchTargetSubdirsSchema>
+  | v.InferOutput<typeof BatchTargetGlobSchema>
+  | v.InferOutput<typeof BatchTargetExplicitSchema>;
+
+export const BatchParamsSchema = v.strictObject({
+  command: v.pipe(
+    v.string(),
+    v.minLength(1, "command is required"),
+    v.maxLength(16384, "command exceeds 16384 bytes"),
+  ),
+  targets: BatchTargetSchema,
+  mode: v.optional(v.picklist(["sequential", "parallel"])),
+  max_concurrent: v.optional(
+    v.pipe(v.number(), v.integer(), v.minValue(1, "max_concurrent must be >= 1")),
+  ),
+  timeout_secs: v.optional(
+    v.pipe(
+      v.number(),
+      v.integer(),
+      v.minValue(1, "timeout_secs must be >= 1"),
+      v.maxValue(3600, "timeout_secs must be <= 3600 (1 hour)"),
+    ),
+  ),
+  fail_fast: v.optional(v.boolean()),
+  summary_only: v.optional(v.boolean()),
+});
+
+export type ParsedBatchParams = v.InferOutput<typeof BatchParamsSchema>;
+
+/**
+ * Alias table for common model mistakes.
+ */
+const KNOWN_PARAM_ALIASES: Record<string, string> = {
+  repos:
+    "unknown parameter 'repos'. Use 'targets' instead (e.g. targets: { kind: 'subdirs', path: '/home/avifenesh/projects' }).",
+  directories:
+    "unknown parameter 'directories'. Use 'targets' instead.",
+  dirs: "unknown parameter 'dirs'. Use 'targets' instead.",
+  paths:
+    "unknown parameter 'paths'. Use 'targets: { kind: 'explicit', paths: [...] }' instead.",
+  git_cmd: "unknown parameter 'git_cmd'. Use 'command' instead.",
+  git_command: "unknown parameter 'git_command'. Use 'command' instead.",
+  cmd: "unknown parameter 'cmd'. Use 'command' instead.",
+  shell_cmd: "unknown parameter 'shell_cmd'. Use 'command' instead.",
+  parallel:
+    "unknown parameter 'parallel'. Use 'mode: 'parallel'' instead.",
+  concurrent:
+    "unknown parameter 'concurrent'. Use 'max_concurrent' instead.",
+  timeout:
+    "unknown parameter 'timeout'. Use 'timeout_secs' instead (seconds, not milliseconds).",
+};
+
+function checkAliases(input: unknown): string[] {
+  if (input === null || typeof input !== "object") return [];
+  const hints: string[] = [];
+  for (const key of Object.keys(input as Record<string, unknown>)) {
+    const hint = KNOWN_PARAM_ALIASES[key];
+    if (hint) hints.push(hint);
+  }
+  return hints;
+}
+
+function makeAliasIssues(messages: string[]): v.BaseIssue<unknown>[] {
+  return messages.map(
+    (m) =>
+      ({
+        kind: "validation" as const,
+        type: "custom" as const,
+        input: undefined,
+        expected: null,
+        received: "unknown",
+        message: m,
+      }) as unknown as v.BaseIssue<unknown>,
+  );
+}
+
+export function safeParseBatchParams(input: unknown):
+  | { ok: true; value: BatchParams }
+  | { ok: false; issues: v.BaseIssue<unknown>[] } {
+  const aliases = checkAliases(input);
+  if (aliases.length > 0) {
+    return { ok: false, issues: makeAliasIssues(aliases) };
+  }
+  const result = v.safeParse(BatchParamsSchema, input);
+  if (result.success) return { ok: true, value: result.output };
+  return { ok: false, issues: result.issues };
+}
+
+// Tool definition exposed to the LLM.
+
+export const BATCH_TOOL_NAME = "batch";
+
+export const BATCH_TOOL_DESCRIPTION = `Execute a shell command across multiple directories. Use for batch git operations, bulk file operations, workspace builds, etc.
+
+Supports three target modes:
+- subdirs: run in each immediate subdirectory of a path
+- glob: run in each path matching a glob pattern
+- explicit: run in each explicitly listed path
+
+Execution modes:
+- sequential: run one at a time, accumulate results
+- parallel: run concurrently (max_concurrent controls concurrency)
+
+Use $TARGET in the command to reference the current directory.
+Use fail_fast to stop on first failure.
+Use summary_only to get counts instead of per-target output.`;
+
+export const batchToolDefinition: ToolDefinition = {
+  name: BATCH_TOOL_NAME,
+  description: BATCH_TOOL_DESCRIPTION,
+  inputSchema: {
+    type: "object",
+    properties: {
+      command: {
+        type: "string",
+        description:
+          "Shell command to run in each target. Use $TARGET to reference the current directory.",
+      },
+      targets: {
+        oneOf: [
+          {
+            type: "object",
+            properties: {
+              kind: { const: "subdirs" },
+              path: {
+                type: "string",
+                description: "Root directory to scan for subdirectories.",
+              },
+              name_filter: {
+                type: "string",
+                description: "Optional name filter (glob pattern for subdirectory names).",
+              },
+            },
+            required: ["kind", "path"],
+          },
+          {
+            type: "object",
+            properties: {
+              kind: { const: "glob" },
+              pattern: {
+                type: "string",
+                description: "Glob pattern for target directories.",
+              },
+            },
+            required: ["kind", "pattern"],
+          },
+          {
+            type: "object",
+            properties: {
+              kind: { const: "explicit" },
+              paths: {
+                type: "array",
+                items: { type: "string" },
+                description: "Explicit list of directory paths.",
+              },
+            },
+            required: ["kind", "paths"],
+          },
+        ],
+      },
+      mode: {
+        type: "string",
+        enum: ["sequential", "parallel"],
+        description: "Execution mode. Default: sequential.",
+      },
+      max_concurrent: {
+        type: "integer",
+        minimum: 1,
+        description: "Max concurrent commands for parallel mode (default 4).",
+      },
+      timeout_secs: {
+        type: "integer",
+        minimum: 1,
+        maximum: 3600,
+        description: "Timeout per command in seconds (default 120).",
+      },
+      fail_fast: {
+        type: "boolean",
+        description: "Stop on first failure (default false).",
+      },
+      summary_only: {
+        type: "boolean",
+        description: "Return only summary counts, not per-target output (default false).",
+      },
+    },
+    required: ["command", "targets"],
+    additionalProperties: false,
+  },
+};

--- a/packages/batch/src/types.ts
+++ b/packages/batch/src/types.ts
@@ -1,0 +1,51 @@
+export type BatchTargetSubdirs = {
+  kind: "subdirs";
+  path: string;
+  name_filter?: string;
+};
+
+export type BatchTargetGlob = {
+  kind: "glob";
+  pattern: string;
+};
+
+export type BatchTargetExplicit = {
+  kind: "explicit";
+  paths: string[];
+};
+
+export type BatchTarget = BatchTargetSubdirs | BatchTargetGlob | BatchTargetExplicit;
+
+export type BatchMode = "sequential" | "parallel";
+
+export interface BatchParams {
+  command: string;
+  targets: BatchTarget;
+  mode?: BatchMode;
+  max_concurrent?: number;
+  timeout_secs?: number;
+  fail_fast?: boolean;
+  summary_only?: boolean;
+}
+
+export type BatchStatus =
+  | "success"
+  | "failed"
+  | "timed_out"
+  | "skipped";
+
+export interface TargetResult {
+  path: string;
+  status: BatchStatus;
+  exit_code?: number;
+  stdout?: string;
+  stderr?: string;
+  duration_ms?: number;
+}
+
+export interface BatchSummary {
+  total: number;
+  success: number;
+  failed: number;
+  timed_out: number;
+}

--- a/packages/batch/test/batch.test.ts
+++ b/packages/batch/test/batch.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { safeParseBatchParams, executeBatch } from "../src/index.js";
+import type { BatchParams } from "../src/types.js";
+
+describe("batch schema", () => {
+  it("parses valid subdirs targets", () => {
+    const result = safeParseBatchParams({
+      command: "echo $TARGET",
+      targets: { kind: "subdirs", path: "/tmp/test-batch" },
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("parses valid glob targets", () => {
+    const result = safeParseBatchParams({
+      command: "ls",
+      targets: { kind: "glob", pattern: "/tmp/test-batch/*" },
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("parses valid explicit targets", () => {
+    const result = safeParseBatchParams({
+      command: "pwd",
+      targets: { kind: "explicit", paths: ["/tmp", "/var"] },
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects empty command", () => {
+    const result = safeParseBatchParams({
+      command: "",
+      targets: { kind: "subdirs", path: "/tmp" },
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects missing targets", () => {
+    const result = safeParseBatchParams({
+      command: "echo hello",
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects empty explicit paths", () => {
+    const result = safeParseBatchParams({
+      command: "echo hello",
+      targets: { kind: "explicit", paths: [] },
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("accepts optional params", () => {
+    const result = safeParseBatchParams({
+      command: "echo hello",
+      targets: { kind: "explicit", paths: ["/tmp"] },
+      mode: "parallel",
+      max_concurrent: 8,
+      timeout_secs: 60,
+      fail_fast: true,
+      summary_only: true,
+    });
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("batch execution", () => {
+  let testDir: string;
+  let subdirs: string[];
+
+  beforeAll(async () => {
+    testDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "batch-test-"),
+    );
+    subdirs = ["repo-a", "repo-b", "repo-c"];
+    for (const name of subdirs) {
+      await fs.mkdir(path.join(testDir, name));
+      await fs.writeFile(
+        path.join(testDir, name, "marker.txt"),
+        name,
+      );
+    }
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  it("runs command in each subdirectory (sequential)", async () => {
+    const params: BatchParams = {
+      command: "cat marker.txt",
+      targets: { kind: "subdirs", path: testDir },
+      mode: "sequential",
+    };
+
+    const result = await executeBatch(params);
+    expect(result.message).toContain("Batch complete: 3 targets");
+    expect(result.meta.targets).toHaveLength(3);
+
+    const targets = result.meta.targets as any[];
+    for (const t of targets) {
+      expect(t.status).toBe("success");
+    }
+  });
+
+  it("runs command in each subdirectory (parallel)", async () => {
+    const params: BatchParams = {
+      command: "cat marker.txt",
+      targets: { kind: "subdirs", path: testDir },
+      mode: "parallel",
+      max_concurrent: 2,
+    };
+
+    const result = await executeBatch(params);
+    expect(result.message).toContain("Batch complete: 3 targets");
+    const targets = result.meta.targets as any[];
+    expect(targets).toHaveLength(3);
+  });
+
+  it("captures failed targets", async () => {
+    const params: BatchParams = {
+      command: "false",
+      targets: { kind: "subdirs", path: testDir },
+      mode: "sequential",
+    };
+
+    const result = await executeBatch(params);
+    const targets = result.meta.targets as any[];
+    for (const t of targets) {
+      expect(t.status).toBe("failed");
+    }
+  });
+
+  it("fail_fast stops on first failure", async () => {
+    const params: BatchParams = {
+      command: "false",
+      targets: { kind: "subdirs", path: testDir },
+      mode: "sequential",
+      fail_fast: true,
+    };
+
+    const result = await executeBatch(params);
+    const targets = result.meta.targets as any[];
+    expect(targets).toHaveLength(1);
+    expect(targets[0].status).toBe("failed");
+  });
+
+  it("summary_only returns counts not details", async () => {
+    const params: BatchParams = {
+      command: "true",
+      targets: { kind: "subdirs", path: testDir },
+      mode: "sequential",
+      summary_only: true,
+    };
+
+    const result = await executeBatch(params);
+    expect(result.message).toContain("3/3 succeeded");
+    expect(result.meta.summary).toBeDefined();
+    expect(result.meta.targets).toBeUndefined();
+  });
+
+  it("handles explicit targets", async () => {
+    const params: BatchParams = {
+      command: "pwd",
+      targets: {
+        kind: "explicit",
+        paths: [path.join(testDir, "repo-a"), path.join(testDir, "repo-b")],
+      },
+    };
+
+    const result = await executeBatch(params);
+    const targets = result.meta.targets as any[];
+    expect(targets).toHaveLength(2);
+  });
+
+  it("handles non-existent explicit paths gracefully", async () => {
+    const params: BatchParams = {
+      command: "pwd",
+      targets: {
+        kind: "explicit",
+        paths: ["/nonexistent/path/that/does/not/exist"],
+      },
+      summary_only: true,
+    };
+
+    const result = await executeBatch(params);
+    // Should fail but not crash
+    expect(result.message).toBeDefined();
+  });
+});
+
+describe("name filtering", () => {
+  let testDir: string;
+
+  beforeAll(async () => {
+    testDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "batch-filter-test-"),
+    );
+    await fs.mkdir(path.join(testDir, "repo-a"));
+    await fs.mkdir(path.join(testDir, "repo-b"));
+    await fs.mkdir(path.join(testDir, "other-c"));
+  });
+
+  afterAll(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  it("filters subdirs by name pattern", async () => {
+    const result = await executeBatch({
+      command: "true",
+      targets: {
+        kind: "subdirs",
+        path: testDir,
+        name_filter: "repo-*",
+      },
+      summary_only: true,
+    });
+
+    const summary = result.meta.summary as any;
+    expect(summary.success).toBe(2);
+  });
+
+  it("filters subdirs by suffix pattern", async () => {
+    const result = await executeBatch({
+      command: "true",
+      targets: {
+        kind: "subdirs",
+        path: testDir,
+        name_filter: "*-a",
+      },
+      summary_only: true,
+    });
+
+    const summary = result.meta.summary as any;
+    expect(summary).toBeDefined();
+    expect(summary.success).toBe(1);
+  });
+});

--- a/packages/batch/tsconfig.json
+++ b/packages/batch/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "exactOptionalPropertyTypes": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "test"]
+}

--- a/packages/batch/tsup.config.ts
+++ b/packages/batch/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["cjs", "esm"],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  external: ["@agent-sh/harness-core", "fast-glob"],
+  treeshake: true,
+  splitting: false,
+});

--- a/packages/batch/vitest.config.ts
+++ b/packages/batch/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+    testTimeout: 30_000,
+  },
+});

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -68,6 +68,11 @@
       "import": "./dist/bash.js",
       "require": "./dist/bash.cjs"
     },
+    "./batch": {
+      "types": "./dist/batch.d.ts",
+      "import": "./dist/batch.js",
+      "require": "./dist/batch.cjs"
+    },
     "./webfetch": {
       "types": "./dist/webfetch.d.ts",
       "import": "./dist/webfetch.js",
@@ -122,6 +127,7 @@
     "@agent-sh/harness-websearch": "workspace:*",
     "@agent-sh/harness-lsp": "workspace:*",
     "@agent-sh/harness-skill": "workspace:*",
+    "@agent-sh/harness-batch": "workspace:*",
     "typebox": "1.1.37"
   },
   "devDependencies": {

--- a/packages/tools/src/batch.ts
+++ b/packages/tools/src/batch.ts
@@ -1,0 +1,1 @@
+export * from "@agent-sh/harness-batch";

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -4,6 +4,7 @@ export * from "@agent-sh/harness-write";
 export * from "@agent-sh/harness-grep";
 export * from "@agent-sh/harness-glob";
 export * from "@agent-sh/harness-bash";
+export * from "@agent-sh/harness-batch";
 export * from "@agent-sh/harness-webfetch";
 // websearch shares SSRF/engine/session helper names with webfetch (classifyHost,
 // createDefaultEngine, newSessionId, …). Re-export only its tool-unique surface

--- a/packages/tools/src/pi-extension.ts
+++ b/packages/tools/src/pi-extension.ts
@@ -18,6 +18,8 @@
  * fence would fail-closed (no hook supplied) and double-gate the call. Roots
  * are anchored at the execute ctx.cwd.
  */
+import fs from "node:fs";
+import path from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { Type, type Static, type TSchema } from "typebox";
 import { formatToolError, InMemoryLedger, type Ledger, type PermissionPolicy, type ToolError } from "@agent-sh/harness-core";
@@ -78,6 +80,12 @@ import {
   FilesystemSkillRegistry,
   type SkillSessionConfig,
 } from "@agent-sh/harness-skill";
+import {
+  executeBatch,
+  batchToolDefinition,
+  safeParseBatchParams,
+  type BatchParams,
+} from "@agent-sh/harness-batch";
 
 // ---------------------------------------------------------------------------
 // Result mapping
@@ -151,6 +159,7 @@ const EditSpecSchema = Type.Object({
   old_string: Type.String(),
   new_string: Type.String(),
   replace_all: Type.Optional(Type.Boolean()),
+  ignore_whitespace: Type.Optional(Type.Boolean({ description: "Ignore leading/trailing whitespace differences when matching." })),
 });
 
 const EditParams = Type.Object({
@@ -159,6 +168,7 @@ const EditParams = Type.Object({
   new_string: Type.String({ description: "Replacement text." }),
   replace_all: Type.Optional(Type.Boolean({ description: "Replace every occurrence instead of requiring uniqueness." })),
   dry_run: Type.Optional(Type.Boolean({ description: "Preview the unified diff without writing." })),
+  ignore_whitespace: Type.Optional(Type.Boolean({ description: "Ignore leading/trailing whitespace differences when matching." })),
 });
 
 const MultiEditParams = Type.Object({
@@ -282,6 +292,35 @@ const SkillParams = Type.Object({
       description: "Positional string or named-argument object for the skill.",
     }),
   ),
+});
+
+// Batch target schemas (union of subdirs, glob, explicit)
+const BatchTargetSubdirs = Type.Object({
+  kind: Type.Literal("subdirs"),
+  path: Type.String({ description: "Root directory to scan for subdirectories." }),
+  name_filter: Type.Optional(Type.String({ description: "Optional name filter for subdirectory names." })),
+});
+const BatchTargetGlob = Type.Object({
+  kind: Type.Literal("glob"),
+  pattern: Type.String({ description: "Glob pattern for target directories." }),
+});
+const BatchTargetExplicit = Type.Object({
+  kind: Type.Literal("explicit"),
+  paths: Type.Array(Type.String(), { description: "Explicit list of directory paths." }),
+});
+
+const BatchParams = Type.Object({
+  command: Type.String({ description: "Shell command to run in each target. Use $TARGET for the current directory." }),
+  targets: Type.Union([BatchTargetSubdirs, BatchTargetGlob, BatchTargetExplicit], {
+    description: "Target selection: subdirs, glob, or explicit.",
+  }),
+  mode: Type.Optional(Type.Union([Type.Literal("sequential"), Type.Literal("parallel")], {
+    description: "Execution mode. Default: sequential.",
+  })),
+  max_concurrent: Type.Optional(Type.Integer({ minimum: 1, description: "Max concurrent commands for parallel mode (default 4)." })),
+  timeout_secs: Type.Optional(Type.Integer({ minimum: 1, maximum: 3600, description: "Timeout per command in seconds (default 120)." })),
+  fail_fast: Type.Optional(Type.Boolean({ description: "Stop on first failure (default false)." })),
+  summary_only: Type.Optional(Type.Boolean({ description: "Return only summary counts (default false)." })),
 });
 
 // ---------------------------------------------------------------------------
@@ -449,4 +488,60 @@ export default function harnessToolsExtension(pi: ExtensionAPI): void {
   register("skill", "Skill", skillToolDefinition.description, SkillParams, (p, cwd, signal) =>
     skill(p, skillSession(cwd, signal)),
   );
+
+  // Batch: parse params with valibot, then execute with workspace fence.
+  register("batch", "Batch", batchToolDefinition.description, BatchParams, async (p, cwd, _signal) => {
+    const parsed = safeParseBatchParams(p);
+    if (!parsed.ok) {
+      return { kind: "error", error: { code: "INVALID_PARAM" as const, message: parsed.issues.map(i => i.message).join("; ") } };
+    }
+    // Resolve targets against cwd, canonicalize to real paths, and fence inside workspace.
+    const realCwd = await fs.promises.realpath(cwd);
+    const isInside = (real: string) => {
+      const rel = path.relative(realCwd, real);
+      // rel === "" means exactly the workspace root; startsWith("..") means escape.
+      return !rel.startsWith("..");
+    };
+
+    const targets = parsed.value.targets;
+    if (targets.kind === "subdirs") {
+      const resolved = path.isAbsolute(targets.path) ? targets.path : path.resolve(cwd, targets.path);
+      const real = await fs.promises.realpath(resolved);
+      if (!isInside(real)) {
+        return { kind: "error", error: { code: "INVALID_PARAM" as const, message: `subdirs path "${targets.path}" resolves outside workspace` } };
+      }
+      parsed.value.targets = { ...targets, path: real };
+    } else if (targets.kind === "glob") {
+      const resolved = path.isAbsolute(targets.pattern) ? targets.pattern : path.resolve(cwd, targets.pattern);
+      // Walk up from the pattern until we find an existing directory to check.
+      let checkPath = resolved;
+      while (checkPath && checkPath !== path.parse(checkPath).root) {
+        try {
+          await fs.promises.access(checkPath);
+          break;
+        } catch {
+          checkPath = path.dirname(checkPath);
+        }
+      }
+      if (checkPath && !isInside(checkPath)) {
+        return { kind: "error", error: { code: "INVALID_PARAM" as const, message: `glob pattern "${targets.pattern}" resolves outside workspace` } };
+      }
+      parsed.value.targets = { ...targets, pattern: resolved };
+    } else if (targets.kind === "explicit") {
+      const resolvedPaths: string[] = [];
+      for (const tp of targets.paths) {
+        const resolved = path.isAbsolute(tp) ? tp : path.resolve(cwd, tp);
+        // Canonicalize first via realpath, then check workspace containment.
+        // This prevents symlink-based bypass of the lexical check.
+        const realPath = await fs.promises.realpath(resolved).catch(() => resolved);
+        if (!isInside(realPath)) {
+          return { kind: "error", error: { code: "INVALID_PARAM" as const, message: `explicit path "${tp}" resolves outside workspace` } };
+        }
+        resolvedPaths.push(realPath);
+      }
+      parsed.value.targets = { ...targets, paths: resolvedPaths };
+    }
+    const result = await executeBatch(parsed.value, cwd);
+    return { kind: "ok", output: result.message + (Object.keys(result.meta).length ? `\n${JSON.stringify(result.meta, null, 2)}` : "") };
+  });
 }

--- a/packages/tools/tsup.config.ts
+++ b/packages/tools/tsup.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     grep: "src/grep.ts",
     glob: "src/glob.ts",
     bash: "src/bash.ts",
+    batch: "src/batch.ts",
     webfetch: "src/webfetch.ts",
     websearch: "src/websearch.ts",
     lsp: "src/lsp.ts",

--- a/packages/write/src/edit.ts
+++ b/packages/write/src/edit.ts
@@ -73,6 +73,7 @@ async function executeEdit(
     old_string: params.old_string,
     new_string: params.new_string,
     replace_all: params.replace_all === true,
+    ignore_whitespace: params.ignore_whitespace === true,
   });
   if ("code" in editResult) return err(editResult);
 

--- a/packages/write/src/engine.ts
+++ b/packages/write/src/engine.ts
@@ -3,6 +3,9 @@ import {
   buildMatchLocations,
   findAllOccurrences,
   findFuzzyCandidates,
+  lineOfOffset,
+  mapStrippedOffsetToOriginal,
+  stripLineWhitespace,
   substringBoundaryCollisions,
 } from "./matching.js";
 import { detectEol, normalizeLineEndings, restoreLineEndings } from "./normalize.js";
@@ -59,7 +62,18 @@ export function applyEdit(
     );
   }
 
-  const offsets = findAllOccurrences(normalizedContent, normalizedOld);
+  // When ignore_whitespace is true, strip leading/trailing whitespace from
+  // each line for matching, then map offsets back to the original content.
+  const ignoreWhitespace = edit.ignore_whitespace === true;
+  let searchHaystack = normalizedContent;
+  let searchNeedle = normalizedOld;
+
+  if (ignoreWhitespace) {
+    searchHaystack = stripLineWhitespace(normalizedContent);
+    searchNeedle = stripLineWhitespace(normalizedOld);
+  }
+
+  const offsets = findAllOccurrences(searchHaystack, searchNeedle);
 
   if (offsets.length === 0) {
     const candidates = findFuzzyCandidates(normalizedContent, normalizedOld);
@@ -87,15 +101,16 @@ export function applyEdit(
   }
 
   // Apply — all matches if replace_all, else the single match.
-  const targetOffsets =
+  let targetOffsets =
     edit.replace_all === true ? offsets : [offsets[0] as number];
+
   const warnings: string[] = [];
 
   if (edit.replace_all === true && offsets.length > 1) {
     const flaggedLines = substringBoundaryCollisions(
       normalizedContent,
       normalizedOld,
-      offsets,
+      targetOffsets,
     );
     if (flaggedLines.length > 0) {
       warnings.push(
@@ -104,12 +119,40 @@ export function applyEdit(
     }
   }
 
-  const newContent = replaceAtOffsets(
-    normalizedContent,
-    normalizedOld,
-    normalizedNew,
-    targetOffsets,
-  );
+  let newContent: string;
+  const needleLines = normalizedOld.split("\n").length;
+  if (ignoreWhitespace) {
+    const mappedOffsets = targetOffsets.map((off) =>
+      mapStrippedOffsetToOriginal(normalizedContent, searchHaystack, off),
+    );
+    if (needleLines > 1) {
+      // Multi-line: find actual match boundaries to preserve surrounding text.
+      newContent = replaceMultilineMatchesAtOffsets(
+        normalizedContent,
+        normalizedNew,
+        mappedOffsets,
+        normalizedOld,
+        needleLines,
+      );
+    } else {
+      // Single-line: find the actual span in the original content using
+      // the stripped needle to handle leading/trailing whitespace diffs.
+      newContent = replaceAtOffsetsWithSpans(
+        normalizedContent,
+        normalizedOld,
+        normalizedNew,
+        mappedOffsets,
+        normalizedOld.trim(),
+      );
+    }
+  } else {
+    newContent = replaceAtOffsets(
+      normalizedContent,
+      normalizedOld,
+      normalizedNew,
+      targetOffsets,
+    );
+  }
 
   return {
     content: restoreLineEndings(newContent, originalEol),
@@ -188,6 +231,115 @@ function replaceAtOffsets(
     cursor = off + needle.length;
   }
   parts.push(haystack.slice(cursor));
+  return parts.join("");
+}
+
+/// Like replaceAtOffsets but finds the actual matched span in the haystack
+/// at each offset (needed when ignore_whitespace makes span lengths differ).
+/// `strippedNeedle` is the leading+trailing whitespace-stripped version of
+/// `needle`, used to locate the match when the original line has different
+/// whitespace from the caller's old_string.
+function replaceAtOffsetsWithSpans(
+  haystack: string,
+  needle: string,
+  replacement: string,
+  offsets: readonly number[],
+  strippedNeedle: string,
+): string {
+  if (offsets.length === 0) return haystack;
+  const parts: string[] = [];
+  let cursor = 0;
+  const lines = haystack.split("\n");
+  for (const off of offsets) {
+    const lineIdx = lineOfOffset(haystack, off) - 1;
+    // Find the needle start within the line only (not the rest of the file).
+    const lineStart = lineIdx === 0 ? 0 : lines.slice(0, lineIdx).reduce((s, l) => s + l.length + 1, 0);
+    const lineEnd = lineIdx === lines.length - 1
+      ? haystack.length
+      : lines.slice(0, lineIdx + 1).reduce((s, l) => s + l.length + 1, 0);
+    const lineSlice = haystack.slice(lineStart, lineEnd);
+    const searchFrom = Math.max(0, cursor - lineStart);
+    const needleIdx = lineSlice.indexOf(strippedNeedle, searchFrom);
+    if (needleIdx >= 0) {
+      const actualStart = lineStart + needleIdx;
+      const spanEnd = actualStart + strippedNeedle.length;
+      parts.push(haystack.slice(cursor, actualStart));
+      parts.push(replacement);
+      cursor = spanEnd;
+    } else {
+      // Fallback: stripped needle not found at this line; use estimated span.
+      // (Shouldn't happen in normal flow but guards against corruption.)
+      const spanEnd = off + needle.length;
+      parts.push(haystack.slice(cursor, off));
+      parts.push(replacement);
+      cursor = spanEnd;
+    }
+  }
+  parts.push(haystack.slice(cursor));
+  return parts.join("");
+}
+
+/// Multi-line whitespace-tolerant replacement that preserves surrounding text
+/// on the first and last matched lines. For a needle like "old1\nold2" matching
+/// inside "prefix old1\nold2 suffix", this replaces only "old1\nold2" and
+/// preserves "prefix " and " suffix".
+/// `needleText` is the original (whitespace-normalized) needle to find boundaries.
+function replaceMultilineMatchesAtOffsets(
+  content: string,
+  replacement: string,
+  offsets: readonly number[],
+  needleText: string,
+  needleLines: number,
+): string {
+  if (offsets.length === 0) return content;
+  const lines = content.split("\n");
+  // Get the stripped first/last lines of the needle for boundary search.
+  const needleLinesArr = needleText.split("\n");
+  const firstLineTrimmed = needleLinesArr[0]?.trim() ?? "";
+  const lastLineTrimmed = needleLinesArr[needleLinesArr.length - 1]?.trim() ?? "";
+
+  const parts: string[] = [];
+  let cursor = 0;
+  for (const off of offsets) {
+    const lineIdx = lineOfOffset(content, off) - 1;
+    const endLine = Math.min(lineIdx + needleLines, lines.length);
+
+    // Byte position of the start of the first affected line.
+    const lineStart = lineIdx === 0
+      ? 0
+      : lines.slice(0, lineIdx).reduce((s, l) => s + l.length + 1, 0);
+    // Byte position of the start of the line AFTER the last affected line.
+    const afterEnd = endLine === lines.length
+      ? content.length
+      : lines.slice(0, endLine).reduce((s, l) => s + l.length + 1, 0);
+
+    // Search for the actual match start within the first line,
+// starting from the cursor-relative position to find the correct occurrence.
+    const firstLineContent = lines[lineIdx] ?? "";
+    const searchFrom = Math.max(0, cursor - lineStart);
+    const matchStartInLine = firstLineContent.indexOf(firstLineTrimmed, searchFrom);
+    const actualStart = matchStartInLine >= 0
+      ? lineStart + matchStartInLine
+      : lineStart;
+
+    // Search for the actual match end within the last line.
+    const lastLineIdx = endLine - 1;
+    const lastLineStart = lastLineIdx === 0
+      ? 0
+      : lines.slice(0, lastLineIdx).reduce((s, l) => s + l.length + 1, 0);
+    const lastLineContent = lines[lastLineIdx] ?? "";
+    const matchEndInLine = lastLineContent.indexOf(lastLineTrimmed);
+    const actualEnd = matchEndInLine >= 0
+      ? lastLineStart + matchEndInLine + lastLineTrimmed.length
+      : afterEnd;
+
+    parts.push(content.slice(cursor, actualStart));
+    parts.push(replacement);
+    // actualEnd already points past the last matched content;
+    // content.slice(cursor) will capture the rest including any separator.
+    cursor = actualEnd;
+  }
+  parts.push(content.slice(cursor));
   return parts.join("");
 }
 

--- a/packages/write/src/matching.ts
+++ b/packages/write/src/matching.ts
@@ -7,6 +7,51 @@ import {
 import { similarity } from "./levenshtein.js";
 import type { FuzzyCandidate, MatchLocation } from "./types.js";
 
+/**
+ * Strip leading/trailing whitespace from each line of the text.
+ * Line boundaries ('\n') are preserved.
+ */
+export function stripLineWhitespace(text: string): string {
+  return text.split("\n").map((line) => line.trim()).join("\n");
+}
+
+/**
+ * Given a byte offset in a whitespace-stripped version of a text,
+ * return the corresponding byte offset in the original text.
+ * The stripped text has the same line count; each line's content
+ * starts at the leading whitespace length.
+ */
+export function mapStrippedOffsetToOriginal(
+  original: string,
+  stripped: string,
+  strippedOffset: number,
+): number {
+  // Find the line index and offset within the stripped line.
+  const origLines = original.split("\n");
+  const stripLines = stripped.split("\n");
+  let bytePos = 0;
+  for (let i = 0; i < stripLines.length; i++) {
+    const stripLine = stripLines[i] ?? "";
+    const lineLen = stripLine.length;
+    if (strippedOffset >= bytePos && strippedOffset < bytePos + lineLen) {
+      // Found the line. Map offset within stripped line to original line.
+      const offsetInStripLine = strippedOffset - bytePos;
+      const origLine = origLines[i] ?? "";
+      const leadWs = origLine.length - origLine.trimStart().length;
+      return (
+        // Sum of bytes before this line in original text.
+        origLines.slice(0, i).reduce((sum, l) => sum + l.length + 1, 0) +
+        leadWs +
+        offsetInStripLine
+      );
+    }
+    // Always advance past this line (including its newline), even for blank lines.
+    bytePos += lineLen + 1;
+  }
+  // Fallback: return stripped offset as-is.
+  return strippedOffset;
+}
+
 /** 1-based line of the offset in the given string. Assumes LF-normalized. */
 export function lineOfOffset(text: string, offset: number): number {
   if (offset <= 0) return 1;

--- a/packages/write/src/multiedit.ts
+++ b/packages/write/src/multiedit.ts
@@ -75,6 +75,7 @@ async function executeMultiEdit(
     old_string: e.old_string,
     new_string: e.new_string,
     replace_all: e.replace_all === true,
+    ignore_whitespace: e.ignore_whitespace === true,
   }));
 
   const pipelineResult = applyPipeline(existingContent, edits);

--- a/packages/write/src/schema.ts
+++ b/packages/write/src/schema.ts
@@ -15,12 +15,14 @@ export const EditParamsSchema = v.object({
   new_string: v.string(),
   replace_all: v.optional(v.boolean()),
   dry_run: v.optional(v.boolean()),
+  ignore_whitespace: v.optional(v.boolean()),
 });
 
 const EditSpecSchema = v.object({
   old_string: NonEmptyString,
   new_string: v.string(),
   replace_all: v.optional(v.boolean()),
+  ignore_whitespace: v.optional(v.boolean()),
 });
 
 export const MultiEditParamsSchema = v.object({
@@ -144,6 +146,11 @@ export const editToolDefinition: ToolDefinition = {
         description:
           "If true, return the unified diff without writing to disk.",
       },
+      ignore_whitespace: {
+        type: "boolean",
+        description:
+          "If true, ignore leading/trailing whitespace differences when matching old_string.",
+      },
     },
     required: ["path", "old_string", "new_string"],
     additionalProperties: false,
@@ -171,6 +178,7 @@ export const multieditToolDefinition: ToolDefinition = {
             old_string: { type: "string" },
             new_string: { type: "string" },
             replace_all: { type: "boolean" },
+            ignore_whitespace: { type: "boolean" },
           },
           required: ["old_string", "new_string"],
           additionalProperties: false,

--- a/packages/write/src/types.ts
+++ b/packages/write/src/types.ts
@@ -10,6 +10,7 @@ export interface EditSpec {
   readonly old_string: string;
   readonly new_string: string;
   readonly replace_all?: boolean | undefined;
+  readonly ignore_whitespace?: boolean | undefined;
 }
 
 export interface WriteParams {
@@ -23,6 +24,7 @@ export interface EditParams {
   readonly new_string: string;
   readonly replace_all?: boolean | undefined;
   readonly dry_run?: boolean | undefined;
+  readonly ignore_whitespace?: boolean | undefined;
 }
 
 export interface MultiEditParams {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,31 @@ importers:
         specifier: ^2.1.4
         version: 2.1.9(@types/node@22.19.17)(jsdom@25.0.1)
 
+  packages/batch:
+    dependencies:
+      '@agent-sh/harness-core':
+        specifier: workspace:*
+        version: link:../core
+      fast-glob:
+        specifier: ^3.3.2
+        version: 3.3.3
+      valibot:
+        specifier: ^1.2.0
+        version: 1.2.0(typescript@5.9.3)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.9.0
+        version: 22.19.17
+      tsup:
+        specifier: ^8.3.5
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.4
+        version: 2.1.9(@types/node@22.19.17)(jsdom@25.0.1)
+
   packages/core:
     dependencies:
       valibot:
@@ -241,6 +266,9 @@ importers:
       '@agent-sh/harness-bash':
         specifier: workspace:*
         version: link:../bash
+      '@agent-sh/harness-batch':
+        specifier: workspace:*
+        version: link:../batch
       '@agent-sh/harness-core':
         specifier: workspace:*
         version: link:../core


### PR DESCRIPTION
## 6 logical commits

```
cbace51 feat(bash): persistent background job store with liveness check
ab89ef4 feat(write): ignore_whitespace edit feature
bb59760 feat: add batch tool — run commands across multiple directories
ff2cedc fix(tools): resolve realpath before workspace containment check
0ba7c32 docs: add session feedback notes for 2026-06-05
9e36202 chore: update pnpm-lock.yaml
```

### Commit 1: Persistent background job store
Jobs persisted to `logDir/job-meta/{jobId}.json` with 7-day TTL, surviving executor recreation.
- Path traversal guard: reject jobId containing `/`, `\`, or `\0` (TS)
- Workspace fencing: skip jobs whose `workspace_root` mismatches (Rust)
- Liveness check: persist child PID, probe via `process.kill(pid, 0)`
- Canonicalize `cwd` before persisting (Rust) so comparison matches
- Eliminated `spawn_sentinel` zombie: uses `kill_on_drop(true)`

### Commit 2: `ignore_whitespace` edit feature
Strip leading/trailing whitespace per-line for matching, map offsets back to original content.
- Single-line mode preserves surrounding text on the line
- Multi-line mode preserves prefix/suffix on boundary lines
- Fixed offset-not-found fallback: newline-boundary offsets advance to next line
- Removed dead `replaceLineRangesAtOffsets` function (TS)
- Fixed TS span search to stay within line bounds

### Commit 3: Batch tool
Run shell commands across subdirs/glob/explicit targets with sequential/parallel modes.
- TS package with 16 tests, Rust crate with full schema/execution engine
- Workspace fencing via realpath canonicalization
- Removed redundant manual timer in TS `runOne`
- Rust: added `workspace_root` param, canonicalizes, fences containment

### Commit 4: Security — PI fence ordering
PI explicit fence was checking containment before resolving realpath, allowing symlink escape.
Now canonicalize first, then check containment.

### Commit 5–6: Docs and lockfile

### Testing
- **TS unit tests**: ~413 tests, 0 failures
- **Rust unit tests**: ~195 tests, 0 failures