### PR TITLE
chore: bump Actions off Node 20 + version Rust crates for release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,15 +15,15 @@ jobs:
     name: TypeScript
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 9.12.0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: pnpm
@@ -44,7 +44,7 @@ jobs:
     name: Rust
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,17 +17,17 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 9.12.0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: pnpm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,7 +711,7 @@ dependencies = [
 
 [[package]]
 name = "harness-tools"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "harness-bash",
  "harness-batch",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "harness-websearch"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/harness-tools/Cargo.toml
+++ b/crates/harness-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-tools"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
@@ -24,6 +24,6 @@ harness-grep = { path = "../grep", version = "0.1.1" }
 harness-glob = { path = "../glob", version = "0.1.1" }
 harness-bash = { path = "../bash", version = "0.2.0" }
 harness-webfetch = { path = "../webfetch", version = "0.1.0" }
-harness-websearch = { path = "../websearch", version = "0.1.0" }
+harness-websearch = { path = "../websearch", version = "0.2.0" }
 harness-lsp = { path = "../lsp", version = "0.1.1" }
 harness-skill = { path = "../skill", version = "0.1.0" }

--- a/crates/websearch/Cargo.toml
+++ b/crates/websearch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "harness-websearch"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
## Summary

Two infra follow-ups after the websearch 0.7.0 release.

### 1. Fix GitHub Actions Node-20 deprecation
The release CI flagged the Node-20 JS actions for forced migration to Node 24 (2026-06-16). Bumped to current majors across `ci.yml`, `release.yml`, `release-rust.yml`:
- `actions/checkout@v4 → v5`
- `actions/setup-node@v4 → v6`
- `pnpm/action-setup@v4 → v6`

Verified non-breaking for our usage: `setup-node@v6`'s only breaking change limits **automatic** caching to npm; our **explicit** `cache: pnpm` still works (and `registry-url` for the npm publish step is unchanged). `pnpm/action-setup@v6` keeps the `version:` input.

### 2. Version the Rust crates for release
The websearch redesign (zero-config keyless, compact format, RRF, etc.) landed in `harness-websearch` but the crate was never bumped — still `0.1.0`, which is already on crates.io. So `release-rust.yml` would skip it.
- `harness-websearch` `0.1.0 → 0.2.0`
- `harness-tools` `0.3.0 → 0.4.0` and its `harness-websearch` dep pin `→ 0.2.0` (Cargo reads `"0.1.0"` as `^0.1.0`, which rejects `0.2.0`)
- `Cargo.lock` regenerated; `cargo build/test --workspace --locked` green (63 websearch tests).

## How the Rust publish happens
`release-rust.yml` triggers on a `rust-v*` tag and publishes every workspace crate whose Cargo.toml version isn't yet on crates.io, in dependency order (idempotent — already-published pairs are skipped). After this merges, pushing a `rust-vX` tag publishes `harness-websearch@0.2.0` + `harness-tools@0.4.0`.
